### PR TITLE
docs: Mermaid diagrams and benchmark comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,20 @@ Context substrate for AI agents. Single binary, append-only event log, subject-b
 
 Not a vector DB. Not an agent framework. Not a knowledge graph. A substrate.
 
-```
-Agent ----MCP----> ctxd ----SQLite----> event log
-                    |                      |
-                    |--- KV view ----------|  (latest value per subject)
-                    |--- FTS view ---------|  (full-text search via FTS5)
-                    |--- Vector view ------|  (HNSW nearest-neighbor)
+```mermaid
+flowchart LR
+    Agent["AI Agent\n(Claude, Cursor, custom)"]
+    MCP["MCP\n(stdio)"]
+    CTXD["ctxd daemon"]
+    LOG["Event Log\n(SQLite)"]
+    KV["KV View"]
+    FTS["FTS View"]
+    VEC["Vector View"]
+
+    Agent -->|"ctx_write\nctx_read\nctx_search"| MCP --> CTXD --> LOG
+    LOG --- KV
+    LOG --- FTS
+    LOG --- VEC
 ```
 
 ## Install and run
@@ -78,7 +86,7 @@ The event log is append-only. Every write is tamper-evident via predecessor hash
 
 ## Architecture
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full picture with diagrams.
+See [docs/architecture.md](docs/architecture.md) for the full picture with diagrams.
 
 Quick version:
 
@@ -150,14 +158,14 @@ Global flag: `--db <path>` (default: `ctxd.db`)
 
 | Document | What it covers |
 |----------|---------------|
-| [ARCHITECTURE.md](docs/ARCHITECTURE.md) | System design, data flow, crate map, diagrams |
+| [architecture.md](docs/architecture.md) | System design, data flow, crate map, diagrams |
 | [events.md](docs/events.md) | CloudEvents schema, canonical form, hash chain |
 | [subjects.md](docs/subjects.md) | Path syntax, recursive reads, glob patterns |
 | [capabilities.md](docs/capabilities.md) | Biscuit tokens, caveats, verification model |
 | [capability-tutorial.md](docs/capability-tutorial.md) | Hands-on walkthrough with CLI commands |
 | [mcp.md](docs/mcp.md) | MCP tool reference with parameter tables |
 | [adapter-guide.md](docs/adapter-guide.md) | How to write ingestion adapters |
-| [benchmarking.md](docs/benchmarking.md) | How to benchmark ctxd against alternatives |
+| [benchmarking.md](docs/benchmarking.md) | Performance numbers and comparisons vs Redis, NATS, Mem0, ChromaDB |
 | [decisions/](docs/decisions/) | Architecture Decision Records |
 
 ## Development

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,76 +1,47 @@
 # Architecture
 
-This document describes what ctxd is, how data flows through it, and how the pieces fit together. Written for engineers who want to understand, extend, or audit the system.
+How ctxd works, how data flows through it, and how the pieces fit together. Written for engineers who want to understand, extend, or audit the system.
 
 ## What ctxd does
 
-ctxd is a daemon that stores and serves context. Context is anything an AI agent might need to know: notes, documents, customer data, code changes, meeting summaries, file contents. It enters ctxd as events, gets indexed into materialized views, and leaves via MCP tool calls, wire protocol queries, or HTTP endpoints.
+ctxd is a daemon that stores and serves context for AI agents. Context is anything an agent might need: notes, documents, customer data, code changes, meeting summaries, file contents. It enters as events, gets indexed into materialized views, and leaves via MCP tool calls, wire protocol queries, or HTTP endpoints.
 
 One binary. One SQLite file. No external services.
 
 ## System overview
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│                           CLIENTS                                     │
-│                                                                       │
-│  Claude Desktop    Cursor    Custom Agent    CLI    Admin UI           │
-│       │               │          │            │        │               │
-│       └──MCP──────────┘──MCP─────┘            │        │               │
-│           (stdio)                              │        │               │
-└───────────┼────────────────────────────────────┼────────┼───────────────┘
-            │                                    │        │
-            ▼                                    ▼        ▼
-┌──────────────────────────────────────────────────────────────────────┐
-│                          ctxd daemon                                  │
-│                                                                       │
-│  ┌─────────────┐  ┌──────────────┐  ┌─────────────────┐             │
-│  │ MCP Server  │  │ Wire Protocol│  │   HTTP Server    │             │
-│  │ (rmcp,      │  │ (MsgPack/TCP │  │   (axum,         │             │
-│  │  stdio)     │  │  port 7778)  │  │    port 7777)    │             │
-│  │             │  │              │  │                   │             │
-│  │ 5 tools:    │  │ 6 verbs:     │  │ 3 endpoints:     │             │
-│  │ ctx_write   │  │ PUB          │  │ GET  /health     │             │
-│  │ ctx_read    │  │ SUB          │  │ POST /v1/grant   │             │
-│  │ ctx_subjects│  │ QUERY        │  │ GET  /v1/stats   │             │
-│  │ ctx_search  │  │ GRANT        │  │                   │             │
-│  │ ctx_subscribe│ │ REVOKE       │  │                   │             │
-│  │             │  │ PING         │  │                   │             │
-│  └──────┬──────┘  └──────┬───────┘  └────────┬──────────┘             │
-│         │                │                    │                        │
-│         └────────────────┼────────────────────┘                        │
-│                          │                                             │
-│                          ▼                                             │
-│                ┌──────────────────┐                                    │
-│                │ Capability Engine│                                    │
-│                │ (biscuit-auth)   │                                    │
-│                │                  │                                    │
-│                │ mint()           │                                    │
-│                │ verify()         │                                    │
-│                │ attenuate()      │                                    │
-│                └────────┬─────────┘                                    │
-│                         │                                              │
-│                         ▼                                              │
-│                ┌──────────────────┐                                    │
-│                │   Event Store    │                                    │
-│                │   (SQLite)       │                                    │
-│                │                  │                                    │
-│                │ append()  ───────┼──── within a single transaction:   │
-│                │ read()           │     1. INSERT event                │
-│                │ read_since()     │     2. UPSERT kv_view             │
-│                │ search()         │     3. INSERT fts_view            │
-│                │ subjects()       │                                    │
-│                │ kv_get()         │                                    │
-│                └────────┬─────────┘                                    │
-│                         │                                              │
-│         ┌───────────────┼───────────────┐                              │
-│         ▼               ▼               ▼                              │
-│  ┌────────────┐  ┌────────────┐  ┌────────────┐                      │
-│  │  KV View   │  │  FTS View  │  │Vector View │                      │
-│  │ latest val │  │SQLite FTS5 │  │HNSW index  │                      │
-│  │ per subject│  │ full-text  │  │ in-memory  │                      │
-│  └────────────┘  └────────────┘  └────────────┘                      │
-└──────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Clients
+        CD[Claude Desktop]
+        CU[Cursor]
+        CA[Custom Agent]
+        CLI[CLI]
+        ADM[Admin UI]
+    end
+
+    subgraph "ctxd daemon"
+        MCP["MCP Server\n(rmcp, stdio)\n\n5 tools:\nctx_write\nctx_read\nctx_subjects\nctx_search\nctx_subscribe"]
+        WIRE["Wire Protocol\n(MsgPack/TCP, :7778)\n\n6 verbs:\nPUB, SUB, QUERY\nGRANT, REVOKE, PING"]
+        HTTP["HTTP Server\n(axum, :7777)\n\n3 endpoints:\nGET /health\nPOST /v1/grant\nGET /v1/stats"]
+
+        CAP["Capability Engine\n(biscuit-auth)\n\nmint / verify / attenuate"]
+
+        STORE["Event Store\n(SQLite)\n\nappend / read / read_since\nsearch / subjects / kv_get"]
+
+        KV["KV View\nlatest value\nper subject"]
+        FTS["FTS View\nSQLite FTS5\nfull-text search"]
+        VEC["Vector View\nHNSW index\nin-memory"]
+    end
+
+    CD & CU & CA -->|MCP stdio| MCP
+    CLI -->|direct| STORE
+    ADM -->|HTTP| HTTP
+    CA -->|TCP| WIRE
+
+    MCP & WIRE & HTTP --> CAP
+    CAP --> STORE
+    STORE --> KV & FTS & VEC
 ```
 
 ## Data model
@@ -79,33 +50,33 @@ One binary. One SQLite file. No external services.
 
 Everything in ctxd is an event. Events follow CloudEvents v1.0 with two extensions.
 
-```
-Event
-├── specversion     "1.0" (always)
-├── id              UUIDv7 (time-ordered, globally unique)
-├── source          "ctxd://cli" (who produced this)
-├── subject         "/work/acme/notes" (path-based address)
-├── type            "ctx.note" (event kind)
-├── time            RFC3339 timestamp
-├── datacontenttype "application/json"
-├── data            { ... } (any JSON payload)
-├── predecessorhash SHA-256 of previous event's canonical form (our extension)
-└── signature       Ed25519 signature (v0.2, our extension)
-```
+| Field | Type | Description |
+|-------|------|-------------|
+| `specversion` | `"1.0"` | Always 1.0 |
+| `id` | UUIDv7 | Time-ordered, globally unique |
+| `source` | string | Who produced this (e.g., `"ctxd://cli"`) |
+| `subject` | string | Path-based address (e.g., `"/work/acme/notes"`) |
+| `type` | string | Event kind (e.g., `"ctx.note"`) |
+| `time` | RFC3339 | When the event was created |
+| `datacontenttype` | string | Always `"application/json"` |
+| `data` | JSON | Any JSON payload |
+| `predecessorhash` | string | SHA-256 of previous event's canonical form (ctxd extension) |
+| `signature` | string | Ed25519 signature (v0.2, ctxd extension) |
 
 ### Predecessor hash chain
 
-```
-Event A ──hash──> Event B ──hash──> Event C
-(no pred)         pred=SHA256(A)    pred=SHA256(B)
+```mermaid
+flowchart LR
+    A["Event A\npredecessorhash = null\n(first in chain)"]
+    B["Event B\npredecessorhash =\nSHA256(canonical(A))"]
+    C["Event C\npredecessorhash =\nSHA256(canonical(B))"]
 
-If someone modifies Event A after the fact:
-  SHA256(A') != SHA256(A) -> Event B's predecessorhash is invalid -> chain breaks
+    A -->|"SHA-256"| B -->|"SHA-256"| C
 ```
 
 Canonical form for hashing: exclude `predecessorhash` and `signature`, sort keys alphabetically, serialize to JSON bytes, SHA-256.
 
-Hash chains are scoped per subject. Events on `/work/acme` and `/personal/journal` have independent chains.
+Hash chains are scoped per subject. Events on `/work/acme` and `/personal/journal` have independent chains. If any event is modified after the fact, the next event's predecessor hash will not match, and the chain breaks.
 
 ### Subjects
 
@@ -129,112 +100,156 @@ Glob patterns (for capabilities):
 
 ### Materialized views
 
-```
-Event Log (source of truth, append-only)
-    |
-    |-- KV View
-    |   One row per subject. Stores the data from the latest event.
-    |   Use case: "What is the current state of customer cust-42?"
-    |   Implementation: SQLite table, UPSERT on every append.
-    |
-    |-- FTS View
-    |   Full-text search index over event data and metadata.
-    |   Use case: "Find everything mentioning 'enterprise plan'"
-    |   Implementation: SQLite FTS5 virtual table.
-    |
-    +-- Vector View
-        HNSW nearest-neighbor index over user-supplied embeddings.
-        Use case: "Find the 10 events most semantically similar to this query"
-        Implementation: instant-distance crate, in-memory, rebuilt on restart.
-        ctxd does NOT generate embeddings. Users supply them.
-```
+All views are derived from the append-only event log and can be rebuilt from it.
+
+| View | What it stores | Use case | Implementation |
+|------|---------------|----------|----------------|
+| **KV** | Latest event data per subject | "Current state of customer cust-42?" | SQLite table, UPSERT on append |
+| **FTS** | Full-text index over event data | "Find everything mentioning 'enterprise plan'" | SQLite FTS5 virtual table |
+| **Vector** | HNSW nearest-neighbor index | "10 most semantically similar events" | instant-distance crate, in-memory, rebuilt on restart |
+
+ctxd does NOT generate embeddings. Users supply them.
 
 ## Crate dependency graph
 
-```
-ctxd-core  (Event, Subject, PredecessorHash. Zero deps on storage/network/auth.)
-    |
-    |-- ctxd-store  (SQLite event log + KV/FTS/vector views. core + sqlx + instant-distance)
-    |
-    |-- ctxd-cap  (Biscuit capability engine. core + biscuit-auth. No dep on store.)
-    |
-    |-- ctxd-adapter-core  (Adapter + EventSink traits. core only.)
-    |       |-- ctxd-adapter-fs  (Filesystem watcher. adapter-core + notify)
-    |       |-- ctxd-adapter-gmail  (stub)
-    |       +-- ctxd-adapter-github  (stub)
-    |
-    |-- ctxd-mcp  (MCP server, 5 tools over stdio. core + store + cap + rmcp)
-    |
-    |-- ctxd-http  (Admin REST API, 3 routes. core + store + cap + axum)
-    |
-    +-- ctxd-cli  (The binary. Wires everything. all crates + clap + tracing + rmp-serde)
+```mermaid
+graph TD
+    CORE["ctxd-core\nEvent, Subject, PredecessorHash\nZero deps on storage/network/auth"]
+
+    STORE["ctxd-store\nSQLite event log\nKV / FTS / Vector views"]
+    CAP["ctxd-cap\nBiscuit capability engine"]
+    ADCORE["ctxd-adapter-core\nAdapter + EventSink traits"]
+
+    ADFS["ctxd-adapter-fs\nFilesystem watcher"]
+    ADGM["ctxd-adapter-gmail\n(stub)"]
+    ADGH["ctxd-adapter-github\n(stub)"]
+
+    MCP["ctxd-mcp\nMCP server, 5 tools\nover stdio"]
+    HTTP["ctxd-http\nAdmin REST API\n3 routes"]
+
+    CLI["ctxd-cli\nThe binary\nWires everything together"]
+
+    CORE --> STORE
+    CORE --> CAP
+    CORE --> ADCORE
+
+    ADCORE --> ADFS
+    ADCORE --> ADGM
+    ADCORE --> ADGH
+
+    CORE & STORE & CAP --> MCP
+    CORE & STORE & CAP --> HTTP
+
+    MCP & HTTP & STORE & CAP & ADCORE --> CLI
 ```
 
 ## Capability model
 
-```
-Mint: root key --> Token(subject="/**", ops=[read,write], expires=never)
-                       |
-Attenuate:             v
-                   Token(subject="/work/**", ops=[read], expires=24h)
-                       |
-Attenuate:             v
-                   Token(subject="/work/acme/**", ops=[read], expires=1h, kind=[ctx.note])
+```mermaid
+flowchart TD
+    ROOT["Root Key"]
+    T1["Token A\nsubject = /**\nops = read, write\nexpires = never"]
+    T2["Token B\nsubject = /work/**\nops = read\nexpires = 24h"]
+    T3["Token C\nsubject = /work/acme/**\nops = read\nexpires = 1h\nkind = ctx.note"]
 
-Each level can only narrow. Never widen.
+    ROOT -->|mint| T1
+    T1 -->|attenuate| T2
+    T2 -->|attenuate| T3
+
+    style T1 fill:#f9f9f9,stroke:#333,stroke-width:2px
+    style T2 fill:#f0f0f0,stroke:#333,stroke-width:2px
+    style T3 fill:#e7e7e7,stroke:#333,stroke-width:2px
 ```
 
-Caveat types in v0.1:
+Each level can only narrow scope. Never widen.
+
+**Caveat types in v0.1:**
 
 | Caveat | Purpose |
 |--------|---------|
 | SubjectMatches | Glob pattern restricting which paths the token can access |
 | OperationAllowed | Which operations: read, write, subjects, search, admin |
 | ExpiresAt | Timestamp after which the token is invalid |
-| KindAllowed | Restrict to specific event types (e.g., only ctx.note) |
+| KindAllowed | Restrict to specific event types (e.g., only `ctx.note`) |
 | RateLimit | Ops/sec cap (stored in token, enforcement is v0.2) |
 
 Verification is datalog-injection-safe. All user inputs are validated against `"`, `)`, `;`, and newline before interpolation into biscuit authorizer code.
 
 ## Write path
 
-```
-Request arrives (MCP, wire, or CLI)
-    |
-    v
-Validate capability token --- rejected? --> return error
-    |
-    v
-Parse subject path ----------- invalid? --> return error
-    |
-    v
-BEGIN TRANSACTION
-    |-- Fetch last event for this subject (for predecessor hash)
-    |-- Compute SHA-256 predecessor hash
-    |-- Generate UUIDv7 event ID
-    |-- INSERT INTO events (...)
-    |-- UPSERT INTO kv_view (...)
-    +-- INSERT INTO fts_view (...)
-COMMIT TRANSACTION
-    |
-    v
-Broadcast to wire protocol SUB listeners
-    |
-    v
-Return { id, subject, predecessorhash }
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Server<br/>(MCP / Wire / CLI)
+    participant CAP as Capability Engine
+    participant DB as Event Store<br/>(SQLite)
+    participant SUB as SUB listeners
+
+    C->>S: write(subject, type, data, token?)
+    S->>CAP: verify(token, subject, "write")
+    alt token invalid
+        CAP-->>S: DENIED
+        S-->>C: error: authorization denied
+    end
+    CAP-->>S: OK
+
+    S->>DB: BEGIN TRANSACTION
+    DB->>DB: Fetch last event for subject
+    DB->>DB: Compute SHA-256 predecessor hash
+    DB->>DB: Generate UUIDv7 event ID
+    DB->>DB: INSERT INTO events
+    DB->>DB: UPSERT INTO kv_view
+    DB->>DB: INSERT INTO fts_view
+    S->>DB: COMMIT
+
+    DB-->>S: {id, subject, predecessorhash}
+    S->>SUB: broadcast event
+    S-->>C: {id, subject, predecessorhash}
 ```
 
-Steps inside the transaction are atomic. Crash at any point = rollback, views stay consistent.
+All steps inside the transaction are atomic. Crash at any point = rollback, views stay consistent with the log.
+
+## Read path
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant S as Server<br/>(MCP / Wire / CLI)
+    participant CAP as Capability Engine
+    participant DB as Event Store<br/>(SQLite)
+
+    C->>S: read(subject, recursive?, token?)
+    S->>CAP: verify(token, subject, "read")
+    alt token invalid
+        CAP-->>S: DENIED
+        S-->>C: error: authorization denied
+    end
+    CAP-->>S: OK
+
+    alt recursive = true
+        S->>DB: SELECT * FROM events<br/>WHERE subject LIKE '/prefix/%'<br/>ORDER BY seq
+    else exact match
+        S->>DB: SELECT * FROM events<br/>WHERE subject = '/exact'<br/>ORDER BY seq
+    end
+
+    DB-->>S: event rows
+    S-->>C: JSON array of events
+```
 
 ## Wire protocol framing
 
+```mermaid
+flowchart LR
+    LEN["Length\n4 bytes\nu32 big-endian\nmax 16 MB"]
+    PAY["MessagePack Payload\nRequest or Response enum"]
+
+    LEN --> PAY
+
+    style LEN fill:#333,color:#fff,stroke:#333
+    style PAY fill:#f9f9f9,stroke:#333,stroke-width:2px
 ```
-+-------------+------------------------------+
-| Length (4B)  | MessagePack payload          |
-| u32 big-end | Request or Response enum     |
-| max 16 MB   |                              |
-+-------------+------------------------------+
-```
+
+Every message on the TCP wire is length-prefixed. The length field is a 4-byte big-endian unsigned integer. The payload is a MessagePack-encoded request or response enum. Maximum payload size is 16 MB.
 
 ## SQLite schema
 
@@ -249,7 +264,7 @@ Indexes on events: `subject`, `time`, `event_type`.
 
 ## What v0.1 does NOT include
 
-| Feature | Status | Reason |
+| Feature | Target | Reason |
 |---------|--------|--------|
 | Federation | v0.3 | Needs conflict resolution, peer discovery |
 | Ed25519 signatures | v0.2 | Key management UX |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -2,26 +2,120 @@
 
 How to measure ctxd's performance and compare it to alternatives.
 
-## What to measure
+## ctxd benchmark results
 
-ctxd competes in the "context for AI agents" space. The relevant benchmarks are:
+Run with `cargo bench -p ctxd-store` on an in-memory SQLite store. Full details in [benchmark-results.md](benchmark-results.md).
 
-| Metric | What it tells you | Target |
-|--------|-------------------|--------|
-| Write throughput | Events per second via append() | >10k events/sec on SQLite |
-| Read latency (exact) | Time to read events for one subject | <1ms p99 |
-| Read latency (recursive) | Time to read a subject tree | <10ms for 1000 events |
-| FTS query latency | Time for a full-text search | <5ms for 100k events |
-| Vector search latency | k-NN query time | <10ms for 10k vectors |
-| MCP tool round-trip | End-to-end time for ctx_read over stdio | <50ms |
-| Wire protocol round-trip | End-to-end time for PUB over TCP | <5ms |
-| Cold start | Time from `ctxd serve` to first successful request | <500ms |
-| Memory at rest | RSS with N events in the store | <50MB for 100k events |
-| DB size per event | SQLite file growth per event | ~500B per event (JSON payload dependent) |
-| Token mint latency | Time to mint a biscuit capability token | <1ms |
-| Token verify latency | Time to verify a token | <1ms |
+| Operation | Latency | Notes |
+|-----------|---------|-------|
+| Append single event | 2.85 ms | Includes store initialization |
+| Append 100 sequential | 375 us/event | Amortized over batch |
+| Read exact (1 event) | 79.74 us | Single subject, single event |
+| Read recursive (100 events) | 1.09 ms | All events under one prefix |
+| Read recursive (1000 events) | 10.03 ms | All events under one prefix |
+| FTS search (100 events) | 987.17 us | SQLite FTS5 |
+| FTS search (10,000 events) | 105.87 ms | SQLite FTS5 |
+| KV get latest | 68.92 us | Latest value for a subject |
 
-## Running benchmarks
+Environment: release build, in-memory SQLite, Criterion v0.5, 100 samples.
+
+## Comparison with alternatives
+
+ctxd is not a database, a message broker, or a vector store. It is a context substrate that combines features from all three. Comparisons below are operation-specific -- each system is benchmarked on the operations it was designed for.
+
+### Feature comparison
+
+| | ctxd | Redis | NATS | SQLite (raw) | Mem0 | ChromaDB |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|
+| Open source | Apache-2.0 | BSD-3 | Apache-2.0 | Public domain | Partial | Apache-2.0 |
+| Self-hosted single binary | Yes | Yes | Yes | Library | No (cloud) | Yes |
+| MCP native | Yes | No | No | No | Partial | No |
+| Append-only event log | Yes | No | Yes (JetStream) | No | No | No |
+| Tamper-evident hash chains | Yes | No | No | No | No | No |
+| Capability-based auth | Yes (Biscuit) | ACL | NKEY/JWT | None | API key | None |
+| Full-text search | Yes (FTS5) | RediSearch | No | Manual | Via LLM | No |
+| Vector search | Yes (HNSW) | RedisVSS | No | No | Yes | Yes |
+| Subject-path addressing | Yes | Key-based | Subject-based | Tables | User/session | Collections |
+
+### Write throughput
+
+| System | Operation | Throughput | Source |
+|--------|-----------|------------|--------|
+| **ctxd** | append (in-process) | ~2,667 events/sec | Criterion bench, sequential appends |
+| **Redis** | SET (pipelined) | ~100,000+ ops/sec | redis-benchmark, single node |
+| **NATS** | PUB (no persistence) | ~10M+ msgs/sec | nats bench, single node |
+| **NATS JetStream** | PUB (persisted) | ~200,000 msgs/sec | NATS docs, single node, file store |
+| **SQLite** | INSERT (WAL mode) | ~50,000 rows/sec | Published benchmarks, single writer |
+| **Mem0** | add() | ~5-50 ops/sec | Requires LLM call per write |
+| **ChromaDB** | add (batch 1000) | ~1,000-5,000 docs/sec | Published benchmarks, depends on embedding model |
+
+**Why ctxd is slower than raw Redis/NATS/SQLite:** Every ctxd append does more work per operation:
+1. Fetch the previous event for predecessor hash computation (1 read)
+2. Compute SHA-256 hash of the canonical form
+3. Generate UUIDv7
+4. INSERT into the event log
+5. UPSERT into the KV view
+6. INSERT into the FTS index
+7. All within a single SQLite transaction
+
+This is 3 writes + 1 read + 1 hash per append, compared to Redis's single key-value SET or NATS's single message publish.
+
+### Read latency
+
+| System | Operation | Latency | Source |
+|--------|-----------|---------|--------|
+| **ctxd** | exact read (1 event) | 80 us | Criterion bench |
+| **ctxd** | recursive read (100 events) | 1.09 ms | Criterion bench |
+| **Redis** | GET | ~0.1-0.5 ms | redis-benchmark, single node |
+| **NATS JetStream** | fetch from stream | ~0.5-2 ms | NATS docs |
+| **SQLite** | SELECT by indexed key | ~10-50 us | Published benchmarks |
+| **Mem0** | get_all() | ~50-200 ms | Network + DB lookup |
+
+### Search latency
+
+| System | Operation | Latency | Source |
+|--------|-----------|---------|--------|
+| **ctxd** | FTS (100 events) | 987 us | Criterion bench |
+| **ctxd** | FTS (10k events) | 105.87 ms | Criterion bench |
+| **Redis + RediSearch** | FT.SEARCH (100k docs) | ~1-5 ms | Redis docs |
+| **ChromaDB** | query (10k vectors, k=10) | ~5-20 ms | Published benchmarks |
+| **Mem0** | search() | ~100-500 ms | Requires LLM for semantic search |
+
+### Vector search
+
+| System | Operation | Latency | Source |
+|--------|-----------|---------|--------|
+| **ctxd** | k-NN (HNSW, in-memory) | Not yet benchmarked | instant-distance crate |
+| **ChromaDB** | query (10k vectors, k=10) | ~5-20 ms | Published benchmarks |
+| **Qdrant** | search (1M vectors, k=10) | ~5-15 ms | Qdrant benchmarks |
+| **Redis + RedisVSS** | FT.SEARCH (100k vectors) | ~1-10 ms | Redis docs |
+
+## Where ctxd wins
+
+- **All-in-one for AI agents.** One binary gives you an event log, KV store, FTS index, vector search, capability auth, and MCP tools. No Redis + Elasticsearch + Qdrant + custom auth stack.
+- **Tamper evidence.** No other system in this category provides hash-chain integrity out of the box. If an event is modified after the fact, the chain breaks.
+- **Capability-based auth with attenuation.** Give a sub-agent a scoped, time-limited, narrowed token. It cannot escalate. Redis ACLs and NATS NKEYs do not support delegation chains.
+- **MCP native.** Connect Claude Desktop or Cursor in 30 seconds. No adapter layer, no SDK, no glue code.
+- **Zero external dependencies.** No Docker Compose, no managed service, no API keys. `cargo build && ctxd serve`.
+- **Subject-path addressing.** Hierarchical namespace with recursive reads and glob-based capability scoping. Natural fit for how context is organized (by project, team, entity).
+
+## Where ctxd loses
+
+- **Raw throughput.** Redis and NATS are purpose-built for speed. ctxd does more work per operation (hash chains, view updates, capability checks). If you need 100k+ writes/sec, ctxd is not the right choice today.
+- **Vector search at scale.** ChromaDB and Qdrant are purpose-built vector databases with optimized indexes, quantization, and sharding. ctxd's vector view is in-memory HNSW rebuilt on restart -- fine for 10k vectors, not for 10M.
+- **FTS at scale.** SQLite FTS5 is solid for small-to-medium datasets. For millions of documents, Elasticsearch or Typesense will be faster and more featureful (facets, fuzzy matching, etc.).
+- **Distributed systems.** NATS has built-in clustering, geo-replication, and super-cluster federation. ctxd is single-node only until v0.3.
+- **Ecosystem maturity.** Redis has 15+ years of production hardening, client libraries in every language, and a massive community. ctxd is v0.1.
+
+## The honest take
+
+ctxd is not trying to beat Redis at key-value storage or Qdrant at vector search. It occupies a different niche: a single substrate that gives AI agents persistent, tamper-evident, capability-scoped context over MCP.
+
+The right comparison is: **what does it cost to assemble the same feature set from separate tools?** Redis + Elasticsearch + Qdrant + custom auth + MCP adapter layer + hash chain verification. That is the alternative ctxd replaces.
+
+For a single developer or small team running AI agents locally, ctxd's performance is more than sufficient. The bottleneck in AI agent workflows is LLM inference (seconds per call), not context storage (microseconds per read).
+
+## Running your own benchmarks
 
 ### Setup
 
@@ -43,16 +137,8 @@ time for i in $(seq 1 10000); do
     --data "{\"i\":$i}" 2>/dev/null
 done
 
-# For higher throughput, use the wire protocol (avoids process spawn overhead):
-# 1. Start daemon: $CTXD --db $DB serve &
-# 2. Use a client that sends PUB over TCP in a loop
-```
-
-The CLI benchmark above includes process spawn overhead (~10ms per invocation). Real throughput via the wire protocol or in-process is 10-100x faster. To measure actual store throughput without process overhead:
-
-```bash
-# Rust benchmark (add to crates/ctxd-store/benches/)
-cargo bench -p ctxd-store
+# Note: CLI benchmark includes process spawn overhead (~10ms per invocation).
+# Real throughput via wire protocol or in-process is 10-100x faster.
 ```
 
 ### Read latency
@@ -101,122 +187,6 @@ time $CTXD --db $DB grant --subject "/**" --operations "read,write,subjects,sear
 # Verify
 TOKEN=$($CTXD --db $DB grant --subject "/**" --operations "read")
 time $CTXD --db $DB verify --token "$TOKEN" --subject /bench/item-1 --operation read
-```
-
-## Comparing to alternatives
-
-### Comparison matrix
-
-| System | Category | Open source | Self-hosted | MCP native | Event log | Cap auth | Federation |
-|--------|----------|-------------|-------------|------------|-----------|----------|------------|
-| **ctxd** | Context substrate | Yes (Apache-2.0) | Yes | Yes | Yes | Yes (biscuit) | v0.3 |
-| Mem0 | AI memory | Partial | No (cloud) | Partial | No | No | No |
-| Zep | AI memory | Partial | Yes | Partial | Partial | No | No |
-| Supermemory | AI memory | Partial | No | Yes | No | No | No |
-| Letta (MemGPT) | Agent framework | Yes | Yes | No | No | No | No |
-| ChromaDB | Vector DB | Yes | Yes | No | No | No | No |
-| Qdrant | Vector DB | Yes | Yes | No | No | No | No |
-| EventSourcingDB | Event store | No (commercial) | Yes | No | Yes | No (single token) | No |
-| NATS | Message broker | Yes | Yes | No | Yes (JetStream) | Partial | Yes |
-
-### What to benchmark against each
-
-**Mem0** (https://mem0.ai)
-- They have a Python SDK. Install: `pip install mem0ai`
-- Compare: write latency (their `add()` vs ctxd `write`), search latency (their `search()` vs ctxd FTS), memory per fact stored
-- Key difference: Mem0 requires an LLM for every write (extraction). ctxd stores raw events. Mem0 will be slower on writes but may return more structured data on reads.
-- Their hosted tier has network latency. Compare against their self-hosted OSS version if possible.
-
-```python
-# Mem0 benchmark sketch
-from mem0 import Memory
-import time
-
-m = Memory()
-start = time.time()
-for i in range(1000):
-    m.add(f"Fact number {i} about benchmarking", user_id="bench")
-write_time = time.time() - start
-print(f"Mem0: {1000/write_time:.0f} writes/sec")
-
-start = time.time()
-for i in range(100):
-    m.search("benchmarking", user_id="bench")
-search_time = time.time() - start
-print(f"Mem0: {100/search_time:.0f} searches/sec")
-```
-
-**Zep** (https://getzep.com)
-- They have a Python SDK and a self-hosted Docker option.
-- Compare: session memory write/read latency, fact extraction latency, search latency
-- Key difference: Zep is session-oriented (conversations). ctxd is subject-oriented (paths). Different data models.
-
-**ChromaDB / Qdrant** (vector DBs)
-- Only compare vector search performance, since these are not context substrates.
-- Use ctxd's vector view (user-supplied embeddings) vs their native vector insert/query.
-- ctxd will be slower on vector operations (in-memory HNSW rebuilt on each insert). This is by design, ctxd is not a vector DB.
-
-```python
-# ChromaDB benchmark sketch
-import chromadb
-import time
-import numpy as np
-
-client = chromadb.Client()
-collection = client.create_collection("bench")
-
-embeddings = np.random.rand(1000, 384).tolist()
-start = time.time()
-collection.add(
-    ids=[f"id-{i}" for i in range(1000)],
-    embeddings=embeddings,
-    documents=[f"Document {i}" for i in range(1000)]
-)
-print(f"ChromaDB insert 1000: {time.time()-start:.3f}s")
-
-query = np.random.rand(384).tolist()
-start = time.time()
-for _ in range(100):
-    collection.query(query_embeddings=[query], n_results=10)
-print(f"ChromaDB 100 queries: {time.time()-start:.3f}s")
-```
-
-**EventSourcingDB** (https://eventsourcingdb.io)
-- Commercial, free tier up to 25k events. Not open source.
-- Compare: event append latency, subject-based read latency, hash chain verification
-- Key difference: EventSourcingDB is a generic event store. ctxd adds capability auth, MCP, materialized views, and is OSS.
-- Use their HTTP API for benchmarking.
-
-**NATS** (https://nats.io)
-- Compare message throughput (NATS PUB/SUB vs ctxd wire PUB/SUB), persistence (JetStream vs ctxd event log).
-- NATS will win on raw message throughput (it's a message broker, not a context store). ctxd wins on context-specific features: subject-based read, FTS, capabilities, MCP.
-- Use `nats bench` tool for NATS side.
-
-```bash
-# NATS benchmark (install nats CLI first)
-nats bench test --pub 1 --msgs 10000 --size 256
-```
-
-### Benchmark reporting template
-
-When publishing benchmark results, include:
-
-```
-Machine:     [CPU, RAM, disk type]
-OS:          [name, version]
-ctxd:        [version, commit hash]
-Competitor:  [name, version]
-Dataset:     [N events, avg event size, N subjects]
-Methodology: [CLI / wire protocol / in-process / SDK]
-
-Results:
-  ctxd write:      X events/sec
-  ctxd read:       X ms (exact), X ms (recursive, N events)
-  ctxd search:     X ms (FTS, N events)
-  ctxd vector:     X ms (k-NN, N vectors, D dimensions)
-  competitor write: X events/sec
-  competitor read:  X ms
-  competitor search: X ms
 ```
 
 ## Writing a Criterion benchmark
@@ -288,12 +258,34 @@ criterion_main!(benches);
 
 Run: `cargo bench -p ctxd-store`
 
+## Benchmark reporting template
+
+When publishing benchmark results, include:
+
+```
+Machine:     [CPU, RAM, disk type]
+OS:          [name, version]
+ctxd:        [version, commit hash]
+Competitor:  [name, version]
+Dataset:     [N events, avg event size, N subjects]
+Methodology: [CLI / wire protocol / in-process / SDK]
+
+Results:
+  ctxd write:      X events/sec
+  ctxd read:       X ms (exact), X ms (recursive, N events)
+  ctxd search:     X ms (FTS, N events)
+  ctxd vector:     X ms (k-NN, N vectors, D dimensions)
+  competitor write: X events/sec
+  competitor read:  X ms
+  competitor search: X ms
+```
+
 ## What ctxd is NOT competing on
 
 Do not benchmark ctxd against:
-- **LLMs** (ctxd stores context, does not generate it)
-- **Agent frameworks** (LangChain, CrewAI, etc. are orchestration layers)
-- **General databases** (Postgres, Redis, DynamoDB are general-purpose)
-- **Search engines** (Elasticsearch, Typesense are full-featured search)
+- **LLMs** -- ctxd stores context, does not generate it
+- **Agent frameworks** -- LangChain, CrewAI are orchestration layers
+- **General databases** -- Postgres, DynamoDB are general-purpose
+- **Search engines** -- Elasticsearch, Typesense are full-featured search
 
 ctxd competes on the combination: event log + subject addressing + capability auth + MCP native + single binary. No single alternative does all five.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -2,7 +2,7 @@
 
 ctxd uses capability-based authorization via [Biscuit tokens](https://www.biscuitsec.org/).
 
-## Concepts
+## Core concepts
 
 - **Capabilities, not ACLs.** Access is granted by possessing a signed token, not by being on a list.
 - **Attenuable.** A token holder can create a restricted version of their token (narrower scope, fewer operations) and pass it to someone else. They cannot widen it.
@@ -17,6 +17,77 @@ ctxd uses capability-based authorization via [Biscuit tokens](https://www.biscui
 | `subjects` | List subjects |
 | `search` | Full-text search events |
 | `admin` | Admin operations (mint new tokens) |
+
+## Token attenuation
+
+Tokens form a tree. Each child token is cryptographically bound to its parent and can only narrow scope, never widen it.
+
+```mermaid
+flowchart TD
+    ROOT["Root Key\n(stored in SQLite metadata)"]
+
+    T1["Agent Token\nsubject: /**\nops: read, write, subjects, search\nexpiry: none"]
+
+    T2["Team Token\nsubject: /work/**\nops: read, write\nexpiry: 30d"]
+
+    T3["Read-Only Token\nsubject: /work/acme/**\nops: read, subjects\nexpiry: 24h"]
+
+    T4["Narrow Token\nsubject: /work/acme/notes/**\nops: read\nexpiry: 1h\nkind: ctx.note"]
+
+    T5["Contractor Token\nsubject: /work/acme/docs/**\nops: read\nexpiry: 7d"]
+
+    ROOT -->|mint| T1
+    T1 -->|attenuate| T2
+    T2 -->|attenuate| T3
+    T3 -->|attenuate| T4
+    T2 -->|attenuate| T5
+
+    style ROOT fill:#333,color:#fff,stroke:#333
+    style T1 fill:#f9f9f9,stroke:#333,stroke-width:2px
+    style T2 fill:#f0f0f0,stroke:#333,stroke-width:2px
+    style T3 fill:#e7e7e7,stroke:#333,stroke-width:2px
+    style T4 fill:#dedede,stroke:#333,stroke-width:2px
+    style T5 fill:#dedede,stroke:#333,stroke-width:2px
+```
+
+## Verification flow
+
+Every operation (read, write, search, etc.) passes through the capability engine before reaching the event store.
+
+```mermaid
+flowchart TD
+    REQ["Incoming request\n(subject, operation, token?)"]
+
+    CHECK{"Token\nprovided?"}
+
+    OPEN["Allow\n(open by default in v0.1)"]
+
+    SIG{"Signature\nvalid?"}
+    DENY1["DENIED\ninvalid signature"]
+
+    SUB{"Subject matches\ntoken glob?"}
+    DENY2["DENIED\nsubject out of scope"]
+
+    OPS{"Operation in\nallowed set?"}
+    DENY3["DENIED\noperation not permitted"]
+
+    EXP{"Token\nexpired?"}
+    DENY4["DENIED\ntoken expired"]
+
+    ALLOW["ALLOWED\nproceed to store"]
+
+    REQ --> CHECK
+    CHECK -->|no| OPEN
+    CHECK -->|yes| SIG
+    SIG -->|no| DENY1
+    SIG -->|yes| SUB
+    SUB -->|no| DENY2
+    SUB -->|yes| OPS
+    OPS -->|no| DENY3
+    OPS -->|yes| EXP
+    EXP -->|yes| DENY4
+    EXP -->|no| ALLOW
+```
 
 ## Minting
 
@@ -40,16 +111,18 @@ ctxd verify --token "<base64>" --subject "/test/hello" --operation read
 
 Tokens can be narrowed via the API. A token for `/**` with `read,write` can be attenuated to `/work/**` with `read` only. The attenuated token is cryptographically bound to the original.
 
+## Caveat types
+
+| Caveat | Description | Example |
+|--------|-------------|---------|
+| Subject glob | Restricts access to subjects matching a glob pattern | `/work/acme/**` |
+| Operation set | Restricts to a set of operations | `read,subjects` |
+| Expiry | Token becomes invalid after a timestamp | `2025-02-01T00:00:00Z` |
+| Kind | Restrict to specific event types | `ctx.note` |
+| Rate limit | Ops/sec cap (enforcement is v0.2) | `100` |
+
 ## v0.1 Limitations
 
-- No revocation. A minted token is valid until it expires.
-- Token expiry is optional (default: no expiry).
-- If no token is provided in an MCP tool call, the operation is allowed (open by default). This is intentional for v0.1 local development.
-
-## Caveat Types
-
-| Caveat | Description |
-|--------|-------------|
-| Subject glob | Restricts access to subjects matching a glob pattern |
-| Operation set | Restricts to a set of operations |
-| Expiry | Token becomes invalid after a timestamp |
+- **No revocation.** A minted token is valid until it expires.
+- **Expiry is optional.** Default: no expiry.
+- **Open by default.** If no token is provided in an MCP tool call, the operation is allowed. Intentional for local development. See [ADR-004](decisions/004-open-by-default.md).

--- a/docs/events.md
+++ b/docs/events.md
@@ -43,37 +43,52 @@ The canonical form excludes `predecessorhash` and `signature` to avoid circular 
 Excluded fields: `predecessorhash`, `signature`
 Included fields (sorted): `data`, `datacontenttype`, `id`, `source`, `specversion`, `subject`, `time`, `type`
 
+## Hash chain integrity
+
+Each subject maintains an independent hash chain. Events link to their predecessor via the `predecessorhash` field, creating a tamper-evident log.
+
+```mermaid
+flowchart LR
+    E1["Event 1\nsubject: /work/acme/notes\n\npredecessorhash = null\n(first event)"]
+    E2["Event 2\nsubject: /work/acme/notes\n\npredecessorhash =\nSHA256(canonical(Event 1))"]
+    E3["Event 3\nsubject: /work/acme/notes\n\npredecessorhash =\nSHA256(canonical(Event 2))"]
+
+    E1 -->|"SHA-256 of\ncanonical form"| E2
+    E2 -->|"SHA-256 of\ncanonical form"| E3
+```
+
+**Tamper detection:** If someone modifies Event 1 after the fact, `SHA256(modified Event 1) != SHA256(original Event 1)`, so Event 2's `predecessorhash` no longer matches. The chain is broken, and the tampering is detectable.
+
+**Per-subject scoping:** Events on `/work/acme` and `/personal/journal` have completely independent chains. Appending to one subject does not affect another subject's chain.
+
+**Verification:** For each event with a `predecessorhash`, compute the hash of the previous event's canonical form and compare. If they don't match, the chain is broken at that point.
+
 ## Signatures
 
 Events can be signed with Ed25519. The signature covers the same canonical form used for predecessor hashing. This proves the event was produced by the holder of the signing key and has not been modified.
 
-```
-Signing flow:
-1. Compute canonical form (same as hashing: exclude predecessorhash/signature, sort keys)
-2. Serialize to JSON bytes
-3. Sign with Ed25519 private key
-4. Hex-encode the signature
-5. Store in the `signature` field
+```mermaid
+flowchart TD
+    subgraph "Signing (write time)"
+        S1["Event fields\n(exclude predecessorhash, signature)"]
+        S2["Sort keys alphabetically"]
+        S3["Serialize to JSON bytes"]
+        S4["Sign with Ed25519 private key"]
+        S5["Hex-encode signature"]
+        S6["Store in signature field"]
 
-Verification flow:
-1. Compute canonical form of the event
-2. Serialize to JSON bytes
-3. Verify the hex-decoded signature against the public key
+        S1 --> S2 --> S3 --> S4 --> S5 --> S6
+    end
+
+    subgraph "Verification (read time)"
+        V1["Recompute canonical form"]
+        V2["Serialize to JSON bytes"]
+        V3["Hex-decode the stored signature"]
+        V4["Verify against public key"]
+        V5["Accept or reject"]
+
+        V1 --> V2 --> V3 --> V4 --> V5
+    end
 ```
 
 The signing key is separate from the capability root key. Capabilities authorize operations. Signatures prove provenance. A single event can have both.
-
-## Hash chain integrity
-
-```
-Subject: /work/acme/notes
-
-Event 1: predecessorhash = null (first event in this subject's chain)
-Event 2: predecessorhash = SHA256(canonical(Event 1))
-Event 3: predecessorhash = SHA256(canonical(Event 2))
-
-Verification: for each event with a predecessorhash, compute the hash of
-the previous event and compare. If they don't match, the chain is broken.
-
-Hash chains are per-subject. Events on different subjects have independent chains.
-```


### PR DESCRIPTION
## Summary

- **Replace all ASCII art with Mermaid diagrams** across `architecture.md`, `events.md`, `capabilities.md`, and `README.md`. Every diagram renders natively on GitHub -- no images to maintain.
- **Add honest benchmark comparisons** in `benchmarking.md` against Redis, NATS, SQLite, Mem0, and ChromaDB with "where ctxd wins" and "where ctxd loses" sections.
- **Fix broken doc link** from `docs/ARCHITECTURE.md` to `docs/architecture.md`.

### Diagrams added (12 total)

| File | Diagram | Type |
|------|---------|------|
| README.md | High-level architecture | flowchart |
| architecture.md | System overview (clients -> daemon -> store -> views) | flowchart |
| architecture.md | Predecessor hash chain | flowchart |
| architecture.md | Crate dependency graph | directed graph |
| architecture.md | Capability attenuation | flowchart |
| architecture.md | Write path | sequence diagram |
| architecture.md | Read path | sequence diagram |
| architecture.md | Wire protocol framing | flowchart |
| events.md | Hash chain linking | flowchart |
| events.md | Signing and verification flow | flowchart |
| capabilities.md | Token attenuation tree | flowchart |
| capabilities.md | Verification flow | flowchart |

### Benchmark comparisons added

Write throughput, read latency, search latency, and vector search tables comparing ctxd against Redis, NATS, SQLite, Mem0, and ChromaDB. Honest about where ctxd is slower (raw throughput, vector at scale, FTS at scale) and why (hash chains, view updates, capability checks per operation).

## Test plan

- [ ] Verify all Mermaid diagrams render on the GitHub PR diff view
- [ ] Verify all internal doc links resolve (no broken links)
- [ ] Confirm no `.rs` source files were modified
- [ ] Review benchmark numbers for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)