### PR TITLE
feat(cap)+docs: persistent rate-limit state + launch-ready polish (SDK milestone PR 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.3.1 — 2026-04-24
+
+The launch-ready polish release. Persistent rate-limit caveat state closes the last v0.3 leftover, three first-party SDKs land alongside the daemon, and the `/v1/peers` admin surface gets a friendlier README + architecture pass.
+
+- **First-party SDKs shipped.** Rust ([`ctxd-client`](clients/rust/ctxd-client/README.md)) on crates.io, Python ([`ctxd-client`](clients/python/ctxd-py/README.md), imports as `ctxd`) on PyPI, TypeScript ([`@ctxd/client`](clients/typescript/ctxd-client/README.md)) on npm. All three pin to the same API contract and run the same conformance corpus.
+- **API contract artifact** at [`docs/api/`](docs/api/) — OpenAPI 3.1 for HTTP, JSON Schema 2020-12 for events, MessagePack hex fixtures for the wire protocol, plus a SDK<->daemon compatibility matrix. The Rust workspace runs the same conformance harness in `crates/ctxd-wire/tests/conformance_corpus.rs` so the daemon is held to the same bar as the SDKs.
+- **HTTP `/v1/peers` admin endpoints.** `GET /v1/peers` lists federation peers; `DELETE /v1/peers/:peer_id` removes one. Mirrors the `ctxd peer list / remove` CLI.
+- **`ctxd-wire` crate split out of `ctxd-cli`.** The MessagePack request/response enums and length-prefixed framing now live in their own leaf crate so SDKs, federation, and embedded servers can take a wire-protocol dep without dragging in storage, capabilities, MCP, or the HTTP admin.
+- **Persistent rate-limit caveat state (3E).** `CaveatState::rate_check(token_id, ops_per_sec)` is now a real per-token 1-second windowed counter on all three backends. `verify_with_state` enforces it as the last gate after budget + approval. New `CapError::RateLimited { ops_per_sec }` variant. SQLite gets a `rate_buckets` table (additive, gated on `IF NOT EXISTS`); Postgres adds the same in `0003_caveats.sql`. Three integration suites pin the admit/deny boundary so a future smoother token-bucket rewrite has a regression net. ADR 011 updated.
+
 ## v0.3 — 2026-04-24
 
 The federation, backends, and adapters release. Five phases delivered across 13 sub-agent runs and one shared review pass. **364 tests passing**, clippy clean, fmt clean. 19 ADRs cover every meaningful design call.

--- a/README.md
+++ b/README.md
@@ -9,16 +9,19 @@ flowchart LR
     A1["Claude Desktop"] -->|"stdio"| MCP
     A2["Claude.ai / Cursor"] -->|"streamable HTTP"| MCP
     A3["Custom agent"] -->|"SSE"| MCP
+    SDK["First-party SDKs<br/>Rust · Python · TS"] -->|"HTTP + wire"| CTXD
     MCP["MCP server<br/>(8 tools)"] --> CTXD["ctxd daemon"]
-    PEER["peer ctxd"] <-->|"replicate"| CTXD
+    PEER["peer ctxd"] <-->|"replicate (TCP)"| CTXD
     GH["GitHub adapter"] --> CTXD
     GM["Gmail adapter"] --> CTXD
     FS["fs adapter"] --> CTXD
-    CTXD --> LOG["Event log<br/>(SQLite | Postgres | DuckDB+S3)"]
+    CTXD --> LOG["Event log<br/>(SQLite · Postgres · DuckDB+S3)"]
     LOG --- KV["KV"]
     LOG --- FTS["FTS"]
     LOG --- VEC["Vector<br/>(HNSW)"]
     LOG --- GRAPH["Graph"]
+    SDK -. "pinned to" .-> API["docs/api/<br/>OpenAPI · JSON Schema · msgpack hex"]
+    CTXD -. "validates against" .-> API
 ```
 
 ## What's in v0.3
@@ -28,8 +31,10 @@ flowchart LR
 - **Multi-transport MCP.** stdio, SSE, and streamable-HTTP serve the same tool surface concurrently. Bearer-token auth on HTTP; tool-arg fallback for stdio.
 - **Real ingestion adapters.** Gmail (OAuth2 device flow + AES-256-GCM token at rest + History API incremental sync). GitHub (PAT + ETag caching + rate-limit handling).
 - **Hybrid search.** Pluggable embedder (OpenAI, Ollama, none); persisted HNSW index via `hnsw_rs`; FTS + vector + Reciprocal Rank Fusion.
-- **Stateful caveats.** `BudgetLimit` (per-token spend ceiling) and `HumanApprovalRequired` (blocking approval flow via `ctxd approve` or `POST /v1/approvals/:id/decide`).
+- **Stateful caveats.** `BudgetLimit` (per-token spend ceiling), `HumanApprovalRequired` (blocking approval flow via `ctxd approve` or `POST /v1/approvals/:id/decide`), and `RateLimited` (persisted per-token 1-second windowed counter).
 - **Causal DAG.** Events carry `parents` so concurrent writes are detected and resolved deterministically (LWW on `(time, id)`). Tamper-evident via predecessor hash chains; signed via Ed25519.
+- **Three first-party SDKs.** Rust ([`ctxd-client`](clients/rust/ctxd-client/README.md)), Python ([`ctxd-client`](clients/python/ctxd-py/README.md), imports as `ctxd`), TypeScript ([`@ctxd/client`](clients/typescript/ctxd-client/README.md)). All three ship at v0.3 and pin to the same [`docs/api/`](docs/api/) contract.
+- **API contract artifact.** [`docs/api/`](docs/api/) is the single source of truth: OpenAPI 3.1 for HTTP, JSON Schema for events, MessagePack hex fixtures for the wire protocol. Every SDK runs the same conformance corpus.
 
 ## Install and run
 
@@ -107,6 +112,49 @@ ctxd serve --storage duckdb-object \
 
 Postgres and DuckDB run a minimal HTTP admin (full daemon over `dyn Store` is a v0.4 follow-up). See [docs/storage-postgres.md](docs/storage-postgres.md) and [docs/storage-duckdb-object.md](docs/storage-duckdb-object.md).
 
+### Build a client
+
+The three first-party SDKs all wrap the same HTTP admin + wire protocol surface. Each has its own README with full quickstart, request/response types, and conformance notes.
+
+**Rust** — [`clients/rust/ctxd-client`](clients/rust/ctxd-client/README.md):
+
+```bash
+cargo add ctxd-client
+```
+
+```rust
+let client = ctxd_client::CtxdClient::connect("http://127.0.0.1:7777").await?
+    .with_wire("127.0.0.1:7778").await?;
+let id = client.write("/work/notes", "ctx.note", json!({"hi": "there"})).await?;
+```
+
+**Python** — [`clients/python/ctxd-py`](clients/python/ctxd-py/README.md). PyPI package is `ctxd-client`, imports as `ctxd`:
+
+```bash
+pip install ctxd-client
+```
+
+```python
+from ctxd import CtxdAsyncClient
+async with CtxdAsyncClient.connect("http://127.0.0.1:7777") as client:
+    await client.with_wire("127.0.0.1:7778")
+    eid = await client.write("/work/notes", "ctx.note", {"hi": "there"})
+```
+
+**TypeScript / JavaScript** — [`clients/typescript/ctxd-client`](clients/typescript/ctxd-client/README.md):
+
+```bash
+npm i @ctxd/client
+```
+
+```ts
+import { CtxdClient } from "@ctxd/client";
+const client = new CtxdClient({ httpUrl: "http://127.0.0.1:7777", wireAddr: "127.0.0.1:7778" });
+const eid = await client.write({ subject: "/work/notes", eventType: "ctx.note", data: { hi: "there" } });
+```
+
+All three SDKs pin to the same [`docs/api/`](docs/api/) contract artifact and run the same conformance corpus.
+
 ## Connect Claude Desktop
 
 ```json
@@ -134,7 +182,7 @@ The event log is append-only. Every write is tamper-evident via predecessor hash
 
 See [docs/architecture.md](docs/architecture.md) for the full picture with diagrams.
 
-ctxd is a Cargo workspace of 14 crates:
+ctxd is a Cargo workspace of 16 crates plus 3 first-party client SDKs:
 
 ```
 ctxd-core             Event struct, Subject paths, hash chains, Ed25519 signing.
@@ -147,11 +195,16 @@ ctxd-cap              Biscuit capabilities. Third-party blocks + caveat enforcem
 ctxd-embed            Embedder trait + NullEmbedder + OpenAI + Ollama impls.
 ctxd-mcp              MCP server. stdio + SSE + streamable-HTTP transports.
 ctxd-http             Admin REST API (health, grant, stats, peers, approvals).
+ctxd-wire             MessagePack wire protocol — request/response enums + framing.
 ctxd-cli              The `ctxd` binary. Wires everything together.
 ctxd-adapter-core     Adapter trait + EventSink for ingestion.
 ctxd-adapter-fs       Filesystem watcher adapter.
 ctxd-adapter-gmail    Real Gmail adapter (OAuth2 device flow + History API).
 ctxd-adapter-github   Real GitHub adapter (PAT + ETag + rate limits).
+
+clients/rust/ctxd-client       Rust SDK (cargo add ctxd-client).
+clients/python/ctxd-py         Python SDK (pip install ctxd-client).
+clients/typescript/ctxd-client TypeScript / JS SDK (npm i @ctxd/client).
 ```
 
 ## API surfaces
@@ -241,6 +294,8 @@ Global flags: `--db <path>` (default `ctxd.db` for SQLite).
 | [benchmarking.md](docs/benchmarking.md) | Methodology + comparisons |
 | [benchmark-results.md](docs/benchmark-results.md) | Latest numbers (HNSW, FTS, federation throughput) |
 | [decisions/](docs/decisions/) | 19 ADRs covering every meaningful design call |
+| [clients/](clients/) | First-party SDKs (Rust / Python / TypeScript) that wrap the daemon API |
+| [docs/api/](docs/api/) | API contract artifact — OpenAPI 3.1, JSON Schema, MessagePack hex fixtures |
 
 ## Client SDKs
 

--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ All three depend on the same `docs/api/` contract and
 ## Development
 
 ```bash
-cargo test --workspace                   # 364 tests (default features)
+cargo test --workspace                   # ~425 tests (default features); --all-features adds postgres/duckdb suites
 cargo test --workspace --all-features    # exercises postgres + duckdb features
 cargo clippy --workspace --all-targets -- -D warnings
 cargo fmt --all --check

--- a/crates/ctxd-cap/src/lib.rs
+++ b/crates/ctxd-cap/src/lib.rs
@@ -79,6 +79,19 @@ pub enum CapError {
     /// wiring rather than ship an unenforced caveat.
     #[error("token carries requires_approval but no CaveatState was provided to enforce it")]
     ApprovalStateMissing,
+
+    /// A `rate_limit_ops_per_sec` caveat tripped: too many verifies for
+    /// the same token within the current 1-second window.
+    ///
+    /// The caller's expected response is to retry after the next
+    /// window boundary (or to back off according to its own policy).
+    /// We surface the declared `ops_per_sec` so logs make the limit
+    /// visible without re-extracting the token.
+    #[error("rate limited: token exceeded {ops_per_sec} ops/sec")]
+    RateLimited {
+        /// The declared per-token ops-per-second cap.
+        ops_per_sec: u32,
+    },
 }
 
 /// The operations that can be authorized.
@@ -133,6 +146,10 @@ pub struct StatefulCaveats {
     /// Operations that require human approval before the verifier
     /// allows them through.
     pub requires_approval: Vec<Operation>,
+    /// The token's per-token ops-per-second rate limit, if any. When
+    /// present, [`CapEngine::verify_with_state`] consults
+    /// [`state::CaveatState::rate_check`] before allowing the op.
+    pub rate_limit_ops_per_sec: Option<u32>,
 }
 
 /// A constraint that can be added to a capability via a third-party block.
@@ -577,6 +594,19 @@ impl CapEngine {
             }
         }
 
+        // 5. Rate-limit enforcement. Runs *last*: budgets and approvals
+        //    have already cleared, so a `RateLimited` reply tells the
+        //    caller "this op was otherwise admissible — back off and
+        //    retry". Putting rate-limit before approval would mean a
+        //    rate-limited token never even reaches the approver, which
+        //    is a worse error message under load.
+        if let Some(ops_per_sec) = stateful.rate_limit_ops_per_sec {
+            // ops_per_sec == 0 is a degenerate cap — surface immediately.
+            if ops_per_sec == 0 || !state.rate_check(&token_id, ops_per_sec).await? {
+                return Err(CapError::RateLimited { ops_per_sec });
+            }
+        }
+
         Ok(())
     }
 
@@ -590,6 +620,12 @@ impl CapEngine {
             authorizer.query(rule!("budget($c, $n) <- budget_limit($c, $n)"))?;
         let approval_rows: Vec<(String,)> =
             authorizer.query(rule!("approval($op) <- requires_approval($op)"))?;
+        // The mint-time fact is `rate_limit_ops_per_sec(<u32>)`. Datalog
+        // integers are i64 on the way out; we narrow to u32 with a
+        // saturating clamp so a malformed token can't poison the
+        // verifier's u32 path.
+        let rate_rows: Vec<(i64,)> =
+            authorizer.query(rule!("rate($n) <- rate_limit_ops_per_sec($n)"))?;
 
         let budget_limit = budget_rows.into_iter().next().map(|(c, n)| BudgetLimit {
             currency: c,
@@ -616,9 +652,20 @@ impl CapEngine {
             }
         }
 
+        let rate_limit_ops_per_sec = rate_rows.into_iter().next().map(|(n,)| {
+            if n <= 0 {
+                0u32
+            } else if n > u32::MAX as i64 {
+                u32::MAX
+            } else {
+                n as u32
+            }
+        });
+
         Ok(StatefulCaveats {
             budget_limit,
             requires_approval,
+            rate_limit_ops_per_sec,
         })
     }
 

--- a/crates/ctxd-cap/src/state.rs
+++ b/crates/ctxd-cap/src/state.rs
@@ -150,18 +150,21 @@ pub trait CaveatState: Send + Sync {
     /// Current budget total for a `(token_id, currency)` pair.
     async fn budget_get(&self, token_id: &str, currency: &str) -> Result<i64, CapError>;
 
-    /// Check whether an operation on `(token_id, op, subject)` is
-    /// within rate limits. Returns `Ok(true)` when the op can proceed,
+    /// Check whether an op against `token_id` is within
+    /// `ops_per_sec`. Returns `Ok(true)` when the op can proceed,
     /// `Ok(false)` when it must be rejected.
     ///
-    /// Default impl in memory is always `true`; concrete backends
-    /// implement sliding-window counters.
-    async fn rate_check(
-        &self,
-        token_id: &str,
-        op: &str,
-        rate_ops_per_sec: u32,
-    ) -> Result<bool, CapError>;
+    /// # Window semantics (v0.3.x)
+    ///
+    /// Implementations use a windowed counter: each call rounds `now()`
+    /// to the start of a 1-second window, atomically increments the
+    /// counter for that window, and returns true iff the post-increment
+    /// count is `<= ops_per_sec`. Rolling over to a new window resets
+    /// the count to 1. Backends MUST persist the `(window_start, count)`
+    /// pair so the window survives a process restart within the same
+    /// second. See ADR 011 — a smoother token-bucket is on the v0.4
+    /// backlog.
+    async fn rate_check(&self, token_id: &str, ops_per_sec: u32) -> Result<bool, CapError>;
 
     /// Record a pending approval request. Returns the approval id
     /// (caller typically uses a UUIDv7 they already generated).
@@ -255,6 +258,9 @@ pub struct InMemoryCaveatState {
     budgets: Mutex<HashMap<(String, String), i64>>,
     approvals: Mutex<HashMap<String, ApprovalDecision>>,
     notifiers: Mutex<HashMap<String, Arc<Notify>>>,
+    /// Per-token sliding-window counter. Key: `token_id`. Value:
+    /// `(window_start_unix_secs, count_in_window)`.
+    rate_windows: Mutex<HashMap<String, (i64, u32)>>,
 }
 
 impl std::fmt::Debug for InMemoryCaveatState {
@@ -327,13 +333,27 @@ impl CaveatState for InMemoryCaveatState {
             .unwrap_or(0))
     }
 
-    async fn rate_check(
-        &self,
-        _token_id: &str,
-        _op: &str,
-        _rate_ops_per_sec: u32,
-    ) -> Result<bool, CapError> {
-        Ok(true)
+    async fn rate_check(&self, token_id: &str, ops_per_sec: u32) -> Result<bool, CapError> {
+        // Floor `now()` to the second to define the window. Concrete
+        // backends do the same arithmetic in SQL — keeping the floor
+        // here keeps the in-memory impl bit-identical to the SQLite
+        // impl on window boundaries, which is what tests pin.
+        let now_secs = chrono::Utc::now().timestamp();
+        let mut g = self
+            .rate_windows
+            .lock()
+            .map_err(|_| CapError::Denied("rate windows lock poisoned".to_string()))?;
+        let entry = g.entry(token_id.to_string()).or_insert((now_secs, 0));
+        if entry.0 != now_secs {
+            // New window — reset the counter to 1 (this verify is the
+            // first hit in the window) and admit it.
+            *entry = (now_secs, 1);
+            return Ok(true);
+        }
+        // Same window — admit iff post-increment count stays under cap.
+        let new_count = entry.1.saturating_add(1);
+        entry.1 = new_count;
+        Ok(new_count <= ops_per_sec)
     }
 
     async fn approval_request(

--- a/crates/ctxd-cap/tests/rate_limit_enforcement.rs
+++ b/crates/ctxd-cap/tests/rate_limit_enforcement.rs
@@ -1,0 +1,165 @@
+//! Integration test: `rate_limit_ops_per_sec` is enforced.
+//!
+//! Mints a token with a 5 ops/sec cap. The first five verifies in the
+//! same second succeed; the sixth must reject with
+//! [`CapError::RateLimited`]. Sleeping past the next 1-second window
+//! boundary admits a fresh hit.
+//!
+//! These cases pin the *exact* admission semantics of the windowed
+//! counter so a future "smoother" token-bucket replacement (see ADR
+//! 011) has a regression net to start from.
+
+use std::time::Duration;
+
+use ctxd_cap::state::InMemoryCaveatState;
+use ctxd_cap::{CapEngine, CapError, Operation};
+
+/// Spin until we land within the first ~250 ms of a wall-clock second
+/// boundary. The rate-limit window is keyed on `now().timestamp()`, so
+/// without this the test could spend its entire 5-hit budget across
+/// two adjacent windows by accident — a flake we'd rather not eat.
+async fn wait_for_window_start() {
+    loop {
+        let now = chrono::Utc::now();
+        // `subsec_millis()` is the ms past the second floor.
+        if now.timestamp_subsec_millis() < 250 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn rate_limit_admits_first_n_blocks_n_plus_one() {
+    let engine = CapEngine::new();
+    // Cap: 5 ops/sec.
+    let token = engine
+        .mint("/**", &[Operation::Read], None, None, Some(5))
+        .expect("mint with rate_limit_ops_per_sec=5");
+
+    let state = InMemoryCaveatState::new();
+    let timeout = Duration::from_secs(5);
+
+    wait_for_window_start().await;
+
+    // Hits 1..=5 within the same second all succeed.
+    for i in 1..=5 {
+        engine
+            .verify_with_state(
+                &token,
+                "/work/x",
+                Operation::Read,
+                None,
+                Some(&state),
+                timeout,
+            )
+            .await
+            .unwrap_or_else(|e| panic!("hit {i} should succeed but got {e:?}"));
+    }
+
+    // Hit 6 in the same window must reject.
+    let res = engine
+        .verify_with_state(
+            &token,
+            "/work/x",
+            Operation::Read,
+            None,
+            Some(&state),
+            timeout,
+        )
+        .await;
+    match res {
+        Err(CapError::RateLimited { ops_per_sec }) => {
+            assert_eq!(
+                ops_per_sec, 5,
+                "RateLimited should surface the declared cap"
+            );
+        }
+        other => panic!("expected RateLimited, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn rate_limit_resets_on_next_window() {
+    let engine = CapEngine::new();
+    let token = engine
+        .mint("/**", &[Operation::Read], None, None, Some(2))
+        .expect("mint");
+
+    let state = InMemoryCaveatState::new();
+    let timeout = Duration::from_secs(5);
+
+    wait_for_window_start().await;
+
+    // Burn through the cap in the current window.
+    for _ in 0..2 {
+        engine
+            .verify_with_state(
+                &token,
+                "/work/x",
+                Operation::Read,
+                None,
+                Some(&state),
+                timeout,
+            )
+            .await
+            .unwrap();
+    }
+    assert!(matches!(
+        engine
+            .verify_with_state(
+                &token,
+                "/work/x",
+                Operation::Read,
+                None,
+                Some(&state),
+                timeout,
+            )
+            .await,
+        Err(CapError::RateLimited { ops_per_sec: 2 })
+    ));
+
+    // Sleep past the next second boundary — the window should reset.
+    // 1.2s is enough to clear any second we started in plus the ~250ms
+    // we waited for at the start.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+
+    // Fresh window admits another hit.
+    engine
+        .verify_with_state(
+            &token,
+            "/work/x",
+            Operation::Read,
+            None,
+            Some(&state),
+            timeout,
+        )
+        .await
+        .expect("post-rollover hit should succeed");
+}
+
+#[tokio::test]
+async fn rate_limit_absent_means_unlimited() {
+    // No `rate_limit_ops_per_sec` fact on the token = no enforcement.
+    // This protects v0.2 tokens that never carried the fact.
+    let engine = CapEngine::new();
+    let token = engine
+        .mint("/**", &[Operation::Read], None, None, None)
+        .expect("mint without rate cap");
+    let state = InMemoryCaveatState::new();
+    let timeout = Duration::from_secs(5);
+
+    for _ in 0..50 {
+        engine
+            .verify_with_state(
+                &token,
+                "/work/x",
+                Operation::Read,
+                None,
+                Some(&state),
+                timeout,
+            )
+            .await
+            .expect("should never rate-limit when fact is absent");
+    }
+}

--- a/crates/ctxd-store-postgres/migrations/0003_caveats.sql
+++ b/crates/ctxd-store-postgres/migrations/0003_caveats.sql
@@ -24,3 +24,15 @@ CREATE TABLE IF NOT EXISTS pending_approvals (
 );
 
 CREATE INDEX IF NOT EXISTS idx_approvals_decision ON pending_approvals (decision);
+
+-- rate_buckets: per-token sliding 1-second window counter used by the
+-- `rate_limit_ops_per_sec` caveat. One row per token; the upsert in
+-- `PostgresCaveatState::rate_check` overwrites `(window_start, count)`
+-- on every roll over. The single-row-per-token shape is intentional —
+-- we only need the *current* second to admit/deny, and persisting the
+-- whole history would cost more than it tells us. (See ADR 011.)
+CREATE TABLE IF NOT EXISTS rate_buckets (
+    token_id     TEXT PRIMARY KEY,
+    window_start TIMESTAMPTZ NOT NULL,
+    count        INTEGER NOT NULL DEFAULT 0
+);

--- a/crates/ctxd-store-postgres/src/caveat_state.rs
+++ b/crates/ctxd-store-postgres/src/caveat_state.rs
@@ -80,15 +80,37 @@ impl CaveatState for PostgresCaveatState {
         }
     }
 
-    async fn rate_check(
-        &self,
-        _token_id: &str,
-        _op: &str,
-        _rate_ops_per_sec: u32,
-    ) -> Result<bool, CapError> {
-        // Same policy as SQLite — the in-memory rate limiter is the
-        // hot path; persistent rate limiting is deferred.
-        Ok(true)
+    async fn rate_check(&self, token_id: &str, ops_per_sec: u32) -> Result<bool, CapError> {
+        // Single-statement upsert mirrors the SQLite impl. The
+        // `date_trunc('second', $2)` floors `now()` to the start of
+        // the current second so two verifies that land in the same
+        // window land on the same `window_start` value. Postgres can
+        // run this as one round-trip with `RETURNING count` — TOCTOU
+        // safe under the per-row lock taken by `INSERT … ON CONFLICT`.
+        let now = chrono::Utc::now();
+        let row = sqlx::query(
+            r#"
+            INSERT INTO rate_buckets (token_id, window_start, count)
+            VALUES ($1, date_trunc('second', $2::timestamptz), 1)
+            ON CONFLICT (token_id) DO UPDATE SET
+                count = CASE
+                    WHEN rate_buckets.window_start = date_trunc('second', $2::timestamptz)
+                        THEN rate_buckets.count + 1
+                    ELSE 1
+                END,
+                window_start = date_trunc('second', $2::timestamptz)
+            RETURNING count
+            "#,
+        )
+        .bind(token_id)
+        .bind(now)
+        .fetch_one(self.store.pool())
+        .await
+        .map_err(map_err)?;
+        let count: i32 = row
+            .try_get("count")
+            .map_err(|e| CapError::Denied(format!("rate_check RETURNING decode: {e}")))?;
+        Ok(count as i64 <= ops_per_sec as i64)
     }
 
     async fn approval_request(

--- a/crates/ctxd-store-postgres/tests/pg_rate_limit.rs
+++ b/crates/ctxd-store-postgres/tests/pg_rate_limit.rs
@@ -1,0 +1,111 @@
+//! Postgres-backed `rate_check` parity tests. Mirrors the SQLite
+//! `rate_limit_persists` integration suite so the two backends pin the
+//! same windowed-counter contract: same-second hits accumulate, hits
+//! past the cap reject, and a new wall-clock second resets the count.
+//!
+//! These tests are no-ops unless `CTXD_PG_URL` is set, matching the
+//! rest of the postgres integration suite.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ctxd_cap::state::CaveatState;
+use ctxd_store_postgres::caveat_state::PostgresCaveatState;
+use ctxd_store_postgres::PostgresStore;
+use sqlx::Executor;
+
+fn pg_url_or_skip(test_name: &str) -> Option<String> {
+    match std::env::var("CTXD_PG_URL") {
+        Ok(url) => Some(url),
+        Err(_) => {
+            eprintln!("[{test_name}] CTXD_PG_URL unset — skipping");
+            None
+        }
+    }
+}
+
+async fn fresh_store() -> PostgresStore {
+    let url = std::env::var("CTXD_PG_URL").expect("CTXD_PG_URL");
+    let admin = sqlx::PgPool::connect(&url).await.expect("admin connect");
+    let schema = format!("ctxd_test_{}", uuid::Uuid::now_v7().simple());
+    admin
+        .execute(format!("CREATE SCHEMA \"{schema}\"").as_str())
+        .await
+        .expect("create schema");
+    drop(admin);
+    let scoped = if url.contains('?') {
+        format!("{url}&options=-c%20search_path%3D{schema}")
+    } else {
+        format!("{url}?options=-c%20search_path%3D{schema}")
+    };
+    PostgresStore::connect(&scoped).await.expect("open store")
+}
+
+async fn wait_for_window_start() {
+    loop {
+        let now = chrono::Utc::now();
+        if now.timestamp_subsec_millis() < 250 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test]
+async fn pg_rate_check_admits_first_n_blocks_n_plus_one() {
+    if pg_url_or_skip("pg_rate_check_admits_first_n_blocks_n_plus_one").is_none() {
+        return;
+    }
+    let store = fresh_store().await;
+    let st: Arc<dyn CaveatState> = Arc::new(PostgresCaveatState::new(store));
+
+    wait_for_window_start().await;
+
+    for _ in 0..5 {
+        assert!(st.rate_check("tok-1", 5).await.unwrap());
+    }
+    assert!(
+        !st.rate_check("tok-1", 5).await.unwrap(),
+        "sixth hit in same second must reject"
+    );
+}
+
+#[tokio::test]
+async fn pg_rate_check_resets_on_next_window() {
+    if pg_url_or_skip("pg_rate_check_resets_on_next_window").is_none() {
+        return;
+    }
+    let store = fresh_store().await;
+    let st: Arc<dyn CaveatState> = Arc::new(PostgresCaveatState::new(store));
+
+    wait_for_window_start().await;
+
+    for _ in 0..2 {
+        assert!(st.rate_check("tok-1", 2).await.unwrap());
+    }
+    assert!(!st.rate_check("tok-1", 2).await.unwrap());
+
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert!(
+        st.rate_check("tok-1", 2).await.unwrap(),
+        "post-rollover hit should be admitted"
+    );
+}
+
+#[tokio::test]
+async fn pg_rate_check_is_per_token() {
+    if pg_url_or_skip("pg_rate_check_is_per_token").is_none() {
+        return;
+    }
+    let store = fresh_store().await;
+    let st: Arc<dyn CaveatState> = Arc::new(PostgresCaveatState::new(store));
+
+    wait_for_window_start().await;
+
+    assert!(st.rate_check("tok-a", 2).await.unwrap());
+    assert!(st.rate_check("tok-a", 2).await.unwrap());
+    assert!(!st.rate_check("tok-a", 2).await.unwrap());
+
+    // Token B is independent.
+    assert!(st.rate_check("tok-b", 2).await.unwrap());
+}

--- a/crates/ctxd-store-sqlite/src/caveat_state.rs
+++ b/crates/ctxd-store-sqlite/src/caveat_state.rs
@@ -83,17 +83,48 @@ impl CaveatState for SqliteCaveatState {
         Ok(row.map(|(v,)| v).unwrap_or(0))
     }
 
-    async fn rate_check(
-        &self,
-        _token_id: &str,
-        _op: &str,
-        _rate_ops_per_sec: u32,
-    ) -> Result<bool, CapError> {
-        // SQLite-backed rate limiting is deferred — the in-memory fast
-        // path in `ctxd-cli::rate_limit::RateLimiter` is the hot path.
-        // We intentionally return `true` here so call sites that layer
-        // both remain correct under either backend.
-        Ok(true)
+    async fn rate_check(&self, token_id: &str, ops_per_sec: u32) -> Result<bool, CapError> {
+        // Sliding 1-second window counter persisted in `rate_buckets`.
+        // The PRIMARY KEY on `token_id` makes the upsert atomic per
+        // SQLite's per-table write lock. On a different second we
+        // *replace* `(window_start, count)` with `(now_secs, 1)`; on
+        // the same second we increment.
+        //
+        // We do this in a single statement using `INSERT … ON CONFLICT`
+        // so two concurrent verifies for the same token cannot both
+        // observe a pre-increment count and both succeed.
+        let now_secs = chrono::Utc::now().timestamp();
+        let mut tx = self.store.pool().begin().await.map_err(map_err)?;
+        sqlx::query(
+            r#"
+            INSERT INTO rate_buckets (token_id, window_start, count)
+            VALUES (?, ?, 1)
+            ON CONFLICT(token_id) DO UPDATE SET
+                count = CASE
+                    WHEN rate_buckets.window_start = excluded.window_start THEN rate_buckets.count + 1
+                    ELSE 1
+                END,
+                window_start = excluded.window_start
+            "#,
+        )
+        .bind(token_id)
+        .bind(now_secs)
+        .execute(&mut *tx)
+        .await
+        .map_err(map_err)?;
+        let row: (i64, i64) = sqlx::query_as(
+            "SELECT window_start, count FROM rate_buckets WHERE token_id = ?",
+        )
+        .bind(token_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(map_err)?;
+        tx.commit().await.map_err(map_err)?;
+        // The post-increment count is what we compare. The ELSE arm
+        // above has already reset count to 1 for a new window so this
+        // comparison is always against the current window's hits.
+        debug_assert_eq!(row.0, now_secs, "rate window should have rolled to now");
+        Ok(row.1 <= ops_per_sec as i64)
     }
 
     async fn approval_request(

--- a/crates/ctxd-store-sqlite/src/caveat_state.rs
+++ b/crates/ctxd-store-sqlite/src/caveat_state.rs
@@ -112,13 +112,12 @@ impl CaveatState for SqliteCaveatState {
         .execute(&mut *tx)
         .await
         .map_err(map_err)?;
-        let row: (i64, i64) = sqlx::query_as(
-            "SELECT window_start, count FROM rate_buckets WHERE token_id = ?",
-        )
-        .bind(token_id)
-        .fetch_one(&mut *tx)
-        .await
-        .map_err(map_err)?;
+        let row: (i64, i64) =
+            sqlx::query_as("SELECT window_start, count FROM rate_buckets WHERE token_id = ?")
+                .bind(token_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(map_err)?;
         tx.commit().await.map_err(map_err)?;
         // The post-increment count is what we compare. The ELSE arm
         // above has already reset count to 1 for a new window so this

--- a/crates/ctxd-store-sqlite/src/store.rs
+++ b/crates/ctxd-store-sqlite/src/store.rs
@@ -476,6 +476,23 @@ impl EventStore {
         .execute(&self.pool)
         .await?;
 
+        // v0.3.x: rate_buckets — sliding 1-second window counter per
+        // token_id, used by the `rate_limit_ops_per_sec` caveat. We
+        // store one row per token: when a verify lands in a different
+        // second we overwrite (window_start, count) with the new
+        // window. The PRIMARY KEY on token_id makes the upsert atomic.
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS rate_buckets (
+                token_id     TEXT PRIMARY KEY,
+                window_start INTEGER NOT NULL,
+                count        INTEGER NOT NULL DEFAULT 0
+            );
+            "#,
+        )
+        .execute(&self.pool)
+        .await?;
+
         Ok(())
     }
 
@@ -1125,6 +1142,7 @@ mod tests {
             "token_budgets",
             "pending_approvals",
             "vector_embeddings",
+            "rate_buckets",
         ] {
             let row: (i64,) = sqlx::query_as(&format!("SELECT COUNT(*) FROM {table}"))
                 .fetch_one(&store.pool)

--- a/crates/ctxd-store-sqlite/tests/rate_limit_persists.rs
+++ b/crates/ctxd-store-sqlite/tests/rate_limit_persists.rs
@@ -1,0 +1,98 @@
+//! Integration test: the rate-limit window survives a daemon restart.
+//!
+//! Without persistence a malicious caller could bounce the daemon to
+//! reset their bucket and burst past the cap — the test pins both
+//! halves of the contract (a) the in-window count is restored after
+//! re-open, and (b) the next 1-second window admits a fresh hit. See
+//! ADR 011.
+//!
+//! These cases also serve as the regression net for a future
+//! token-bucket rewrite: any replacement must preserve "exactly N
+//! verifies admitted within the same wall-clock second, period".
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use ctxd_cap::state::CaveatState;
+use ctxd_store_sqlite::caveat_state::SqliteCaveatState;
+use ctxd_store_sqlite::EventStore;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn rate_window_count_persists_across_restart() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("ctxd.db");
+
+    // Pick a small cap so we can exhaust it fast and have a clear
+    // admit/deny boundary.
+    let cap_per_sec: u32 = 3;
+
+    // Lifetime 1 — burn 2 of 3 within the current window.
+    {
+        let store = EventStore::open(&db_path).await.expect("open db");
+        let st: Arc<dyn CaveatState> = Arc::new(SqliteCaveatState::new(store));
+
+        // Wait for a window boundary so the two checks here, plus the
+        // third one after restart, all share a wall-clock second.
+        wait_for_window_start().await;
+
+        assert!(st.rate_check("tok-1", cap_per_sec).await.unwrap());
+        assert!(st.rate_check("tok-1", cap_per_sec).await.unwrap());
+    }
+
+    // Lifetime 2 — re-open the same DB. The third hit in the same
+    // wall-clock second must succeed (count goes to 3 == cap), but
+    // the fourth must reject.
+    let store = EventStore::open(&db_path).await.expect("re-open db");
+    let st: Arc<dyn CaveatState> = Arc::new(SqliteCaveatState::new(store));
+
+    assert!(
+        st.rate_check("tok-1", cap_per_sec).await.unwrap(),
+        "third hit at cap should be admitted"
+    );
+    assert!(
+        !st.rate_check("tok-1", cap_per_sec).await.unwrap(),
+        "fourth hit in same window must be rejected"
+    );
+
+    // Sleep past the window boundary; the next hit is admitted again.
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    assert!(
+        st.rate_check("tok-1", cap_per_sec).await.unwrap(),
+        "post-rollover hit should be admitted"
+    );
+}
+
+#[tokio::test]
+async fn rate_check_independent_per_token() {
+    let tmp = TempDir::new().expect("tempdir");
+    let db_path = tmp.path().join("ctxd.db");
+    let store = EventStore::open(&db_path).await.expect("open");
+    let st: Arc<dyn CaveatState> = Arc::new(SqliteCaveatState::new(store));
+
+    wait_for_window_start().await;
+
+    // Burn token A's 2-op cap.
+    assert!(st.rate_check("tok-a", 2).await.unwrap());
+    assert!(st.rate_check("tok-a", 2).await.unwrap());
+    assert!(!st.rate_check("tok-a", 2).await.unwrap());
+
+    // Token B's window is independent — first hit is admitted.
+    assert!(
+        st.rate_check("tok-b", 2).await.unwrap(),
+        "second token shares no state with the first"
+    );
+}
+
+/// Spin until we land within the first ~250 ms of the current second.
+/// Without this, a test that does N hits could span two wall-clock
+/// seconds and lose its admit/deny invariant.
+async fn wait_for_window_start() {
+    loop {
+        let now = chrono::Utc::now();
+        if now.timestamp_subsec_millis() < 250 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,30 +20,41 @@ flowchart TB
         CA[Custom Agent]
         CLI[CLI]
         ADM[Admin UI]
+        SDK["First-party SDKs<br/>Rust · Python · TS"]
     end
 
     subgraph "ctxd daemon"
-        MCP["MCP Server\n(rmcp, stdio)\n\n5 tools:\nctx_write\nctx_read\nctx_subjects\nctx_search\nctx_subscribe"]
-        WIRE["Wire Protocol\n(MsgPack/TCP, :7778)\n\n6 verbs:\nPUB, SUB, QUERY\nGRANT, REVOKE, PING"]
-        HTTP["HTTP Server\n(axum, :7777)\n\nendpoints:\nGET /health\nPOST /v1/grant\nGET /v1/stats\nGET /v1/peers\nDELETE /v1/peers/:id\nGET /v1/approvals\nPOST /v1/approvals/:id/decide"]
+        MCP["MCP Server<br/>(rmcp; stdio + SSE + streamable-HTTP)<br/><br/>8 tools:<br/>ctx_write · ctx_read · ctx_subjects<br/>ctx_search · ctx_subscribe<br/>ctx_entities · ctx_related · ctx_timeline"]
+        WIRE["Wire Protocol<br/>(MsgPack/TCP, :7778)<br/><br/>verbs:<br/>PUB · SUB · QUERY · GRANT · REVOKE · PING<br/>PEER_HELLO · PEER_WELCOME<br/>PEER_REPLICATE · PEER_ACK<br/>PEER_CURSOR_REQUEST · PEER_CURSOR<br/>PEER_FETCH_EVENTS"]
+        HTTP["HTTP Server<br/>(axum, :7777)<br/><br/>endpoints:<br/>GET /health · POST /v1/grant<br/>GET /v1/stats<br/>GET /v1/peers · DELETE /v1/peers/:id<br/>GET /v1/approvals<br/>POST /v1/approvals/:id/decide"]
 
-        CAP["Capability Engine\n(biscuit-auth)\n\nmint / verify / attenuate"]
+        CAP["Capability Engine<br/>(biscuit-auth)<br/><br/>mint · verify · attenuate · third-party blocks<br/>Stateful caveats: BudgetLimit · HumanApproval · RateLimited"]
 
-        STORE["Event Store\n(SQLite)\n\nappend / read / read_since\nsearch / subjects / kv_get"]
+        STORE["Store trait<br/>(ctxd-store-core)<br/><br/>SQLite (default) · Postgres · DuckDB+S3<br/>append · read · read_at · search<br/>subjects · kv_get · graph · timeline"]
 
-        KV["KV View\nlatest value\nper subject"]
-        FTS["FTS View\nSQLite FTS5\nfull-text search"]
-        VEC["Vector View\nHNSW index\nin-memory"]
+        KV["KV View<br/>latest value<br/>per subject"]
+        FTS["FTS View<br/>FTS5 · tsvector<br/>full-text search"]
+        VEC["Vector View<br/>HNSW (hnsw_rs)<br/>persisted sidecar"]
+        GRAPH["Graph View<br/>entities + relationships<br/>derived from events"]
     end
 
-    CD & CU & CA -->|MCP stdio| MCP
+    PEER["Peer ctxd<br/>federation"]
+    API["docs/api/<br/>OpenAPI · JSON Schema · msgpack hex"]
+
+    CD & CU & CA -->|MCP| MCP
     CLI -->|direct| STORE
     ADM -->|HTTP| HTTP
-    CA -->|TCP| WIRE
+    CA & SDK -->|TCP wire| WIRE
+    SDK -->|HTTP| HTTP
+
+    PEER <-->|replicate| WIRE
 
     MCP & WIRE & HTTP --> CAP
     CAP --> STORE
-    STORE --> KV & FTS & VEC
+    STORE --> KV & FTS & VEC & GRAPH
+
+    SDK -. "pinned to" .-> API
+    HTTP & WIRE -. "validates against" .-> API
 ```
 
 ## Data model
@@ -106,44 +117,66 @@ All views are derived from the append-only event log and can be rebuilt from it.
 
 | View | What it stores | Use case | Implementation |
 |------|---------------|----------|----------------|
-| **KV** | Latest event data per subject | "Current state of customer cust-42?" | SQLite table, UPSERT on append |
-| **FTS** | Full-text index over event data | "Find everything mentioning 'enterprise plan'" | SQLite FTS5 virtual table |
-| **Vector** | HNSW nearest-neighbor index | "10 most semantically similar events" | instant-distance crate, in-memory, rebuilt on restart |
+| **KV** | Latest event data per subject | "Current state of customer cust-42?" | SQLite table / Postgres row, UPSERT on append; LWW on `(time, id)` |
+| **FTS** | Full-text index over event data | "Find everything mentioning 'enterprise plan'" | SQLite FTS5 virtual table; Postgres `tsvector` generated column + GIN |
+| **Vector** | HNSW nearest-neighbor index | "10 most semantically similar events" | `hnsw_rs` 0.3 with on-disk sidecars (`<db>.hnsw.{graph,data,meta,map}`); rebuilt from `vector_embeddings` on corruption |
+| **Graph** | Entities + relationships extracted from event payloads | "All events related to entity cust-42" | SQLite `graph_entities` + `graph_relationships` (mirrored in Postgres) |
+| **Temporal** | Point-in-time event reconstruction | "What did `/work/acme/cust-42` look like on 2025-01-15?" | derived view over the events table by `time` predicate |
 
-ctxd does NOT generate embeddings. Users supply them.
+ctxd does NOT generate embeddings — the `Embedder` trait wraps OpenAI / Ollama / Null providers and the daemon stores whatever vector the embedder returns. Hybrid search (FTS + vector + Reciprocal Rank Fusion at `k=60`) is the default mode when an embedder is configured. See [embeddings.md](embeddings.md) and ADRs 014 / 015.
 
 ## Crate dependency graph
 
 ```mermaid
 graph TD
-    CORE["ctxd-core\nEvent, Subject, PredecessorHash\nZero deps on storage/network/auth"]
+    CORE["ctxd-core<br/>Event · Subject · PredecessorHash · Ed25519<br/>zero deps on storage/network/auth"]
 
-    STORE["ctxd-store\nSQLite event log\nKV / FTS / Vector views"]
-    CAP["ctxd-cap\nBiscuit capability engine"]
-    ADCORE["ctxd-adapter-core\nAdapter + EventSink traits"]
+    STC["ctxd-store-core<br/>Store trait + DTOs<br/>conformance test suite"]
+    SS["ctxd-store-sqlite<br/>SQLite + FTS5 + HNSW + graph"]
+    SP["ctxd-store-postgres<br/>tsvector FTS · advisory-lock TOCTOU"]
+    SD["ctxd-store-duckobj<br/>Parquet + WAL + sidecar"]
+    SHIM["ctxd-store<br/>back-compat shim"]
 
-    ADFS["ctxd-adapter-fs\nFilesystem watcher"]
-    ADGM["ctxd-adapter-gmail\n(stub)"]
-    ADGH["ctxd-adapter-github\n(stub)"]
+    CAP["ctxd-cap<br/>biscuit · third-party blocks<br/>BudgetLimit · HumanApproval · RateLimited"]
+    EMBED["ctxd-embed<br/>Embedder trait<br/>OpenAI · Ollama · Null"]
 
-    MCP["ctxd-mcp\nMCP server, 5 tools\nover stdio"]
-    HTTP["ctxd-http\nAdmin REST API\n3 routes"]
+    WIRE["ctxd-wire<br/>MessagePack request/response enums<br/>length-prefixed framing (leaf crate)"]
 
-    CLI["ctxd-cli\nThe binary\nWires everything together"]
+    ADCORE["ctxd-adapter-core<br/>Adapter + EventSink traits"]
+    ADFS["ctxd-adapter-fs<br/>filesystem watcher"]
+    ADGM["ctxd-adapter-gmail<br/>OAuth2 device flow + History API"]
+    ADGH["ctxd-adapter-github<br/>PAT + ETag + rate limits"]
 
-    CORE --> STORE
+    MCP["ctxd-mcp<br/>stdio + SSE + streamable-HTTP<br/>8 tools"]
+    HTTP["ctxd-http<br/>admin REST · approvals · peers"]
+    CLI["ctxd-cli<br/>the ctxd binary"]
+
+    SDKR["clients/rust/ctxd-client"]
+    SDKP["clients/python/ctxd-py"]
+    SDKT["clients/typescript/ctxd-client"]
+
+    CORE --> STC
+    STC --> SS & SP & SD
+    SS --> SHIM
     CORE --> CAP
+    CORE --> EMBED
     CORE --> ADCORE
+    CORE --> WIRE
 
-    ADCORE --> ADFS
-    ADCORE --> ADGM
-    ADCORE --> ADGH
+    ADCORE --> ADFS & ADGM & ADGH
 
-    CORE & STORE & CAP --> MCP
-    CORE & STORE & CAP --> HTTP
+    CORE & STC & CAP --> MCP
+    CORE & STC & CAP --> HTTP
+    CORE & WIRE --> CLI
 
-    MCP & HTTP & STORE & CAP & ADCORE --> CLI
+    MCP & HTTP & SS & SP & SD & CAP & ADCORE & WIRE --> CLI
+
+    SDKR -. "wraps" .-> HTTP & WIRE
+    SDKP -. "wraps" .-> HTTP & WIRE
+    SDKT -. "wraps" .-> HTTP & WIRE
 ```
+
+`ctxd-wire` is a leaf crate — it depends on `ctxd-core` for the `Event` type but is not depended on by anything inside the workspace except `ctxd-cli` (the binary) and the Rust SDK. Splitting it out means downstream consumers (the three SDKs, federation, embedded servers) can take a wire-protocol dep without dragging in storage, capabilities, MCP, or the HTTP admin.
 
 ## Capability model
 
@@ -165,15 +198,18 @@ flowchart TD
 
 Each level can only narrow scope. Never widen.
 
-**Caveat types in v0.1:**
+**Caveat types (v0.3):**
 
-| Caveat | Purpose |
-|--------|---------|
-| SubjectMatches | Glob pattern restricting which paths the token can access |
-| OperationAllowed | Which operations: read, write, subjects, search, admin |
-| ExpiresAt | Timestamp after which the token is invalid |
-| KindAllowed | Restrict to specific event types (e.g., only `ctx.note`) |
-| RateLimit | Ops/sec cap (stored in token, enforcement is v0.2) |
+| Caveat | Purpose | State |
+|--------|---------|-------|
+| SubjectMatches | Glob pattern restricting which paths the token can access | static |
+| OperationAllowed | Which operations: `read`, `write`, `subjects`, `search`, `admin`, `peer`, `subscribe` | static |
+| ExpiresAt | Timestamp after which the token is invalid | static |
+| KindAllowed | Restrict to specific event types (e.g., only `ctx.note`) | static |
+| RateLimit | `ops_per_sec` cap, persisted 1-second windowed counter (ADR 011) | stateful |
+| BudgetLimit | `(currency, amount_micro_units)` cumulative spend cap with per-op cost table | stateful |
+| HumanApprovalRequired | Each verify for the named op blocks until a human decides | stateful |
+| Third-party block | Authority-signed attenuation (e.g. `A → B → C` chain) verified via `verify_multi` | static |
 
 Verification is datalog-injection-safe. All user inputs are validated against `"`, `)`, `;`, and newline before interpolation into biscuit authorizer code.
 
@@ -188,10 +224,18 @@ sequenceDiagram
     participant SUB as SUB listeners
 
     C->>S: write(subject, type, data, token?)
-    S->>CAP: verify(token, subject, "write")
-    alt token invalid
+    S->>CAP: verify_with_state(token, subject, "write", state)
+    alt token invalid (static caveats fail)
         CAP-->>S: DENIED
         S-->>C: error: authorization denied
+    else budget exceeded
+        CAP-->>S: BudgetExceeded
+        S-->>C: error: budget exceeded
+    else approval required
+        CAP-->>CAP: blocking approval_wait(timeout)
+    else rate limited
+        CAP-->>S: RateLimited
+        S-->>C: error: rate limited (back off)
     end
     CAP-->>S: OK
 
@@ -256,25 +300,50 @@ Every message on the TCP wire is length-prefixed. The length field is a 4-byte b
 ## SQLite schema
 
 ```sql
-events           -- append-only event log (seq, id, source, subject, type, time, data, predecessorhash)
-kv_view          -- latest value per subject (subject PK, data, updated_at)
-fts_view         -- FTS5 virtual table (event_id, subject, event_type, data)
-metadata         -- daemon config (key-value, stores root capability key)
+events             -- append-only event log: seq, id, source, subject, event_type, time,
+                   --                       data, predecessorhash, signature, parents,
+                   --                       attestation
+event_parents      -- causal-DAG side table (event_id, parent_id) for parent backfill
+kv_view            -- latest value per subject (subject PK, data, updated_at)
+fts_view           -- FTS5 virtual table (event_id, subject, event_type, data)
+graph_entities     -- materialized entities extracted from event payloads
+graph_relationships -- edges between entities
+revoked_tokens     -- biscuit token revocation list (token_id PK)
+peers              -- federation peers (peer_id, public_key, url, scopes, …)
+peer_cursors       -- last-seen cursor per peer for resume
+token_budgets      -- BudgetLimit per (token_id, currency)
+pending_approvals  -- HumanApprovalRequired queue (approval_id, decision, …)
+rate_buckets       -- RateLimit 1-second windowed counter per token_id
+vector_embeddings  -- raw vectors backing the persisted HNSW index
+metadata           -- daemon config and ctxd_version stamp
 ```
 
-Indexes on events: `subject`, `time`, `event_type`.
+Postgres mirrors the same logical tables with Postgres-native types (`UUID`, `JSONB`, `TIMESTAMPTZ`, `UUID[]`, `BYTEA`); see `docs/storage-postgres.md` and ADR 016 for the schema choices.
 
-## What v0.1 does NOT include
+DuckDB+object-store keeps the event log as Parquet files behind an atomic `_manifest.json` and uses a SQLite sidecar for the same KV / peers / caveats / vectors / graph tables (ADR 018).
+
+## Client SDKs
+
+Three first-party SDKs ship at v0.3 alongside the daemon. All three pin to the same [`docs/api/`](api/) contract artifact (OpenAPI 3.1 + JSON Schema + MessagePack hex fixtures) and run the same conformance corpus, so a wire change either lands in every SDK or fails CI.
+
+| Language | Package | Path | Source of truth |
+|----------|---------|------|-----------------|
+| Rust | `ctxd-client` (crates.io) | [`clients/rust/ctxd-client`](../clients/rust/ctxd-client/README.md) | yes |
+| Python | `ctxd-client` on PyPI (imports as `ctxd`) | [`clients/python/ctxd-py`](../clients/python/ctxd-py/README.md) | mirrors Rust |
+| TypeScript / JS | `@ctxd/client` on npm | [`clients/typescript/ctxd-client`](../clients/typescript/ctxd-client/README.md) | mirrors Rust |
+
+The Rust SDK's API surface is the source of truth; Python and TypeScript mirror it method-for-method, with language-idiomatic naming and async ergonomics. The Rust workspace runs the same conformance harness in `crates/ctxd-wire/tests/conformance_corpus.rs` so the daemon is held to the same bar as the SDKs.
+
+## What v0.3 does NOT include
 
 | Feature | Target | Reason |
 |---------|--------|--------|
-| Federation | v0.3 | Needs conflict resolution, peer discovery |
-| Ed25519 signatures | v0.2 | Key management UX |
-| Token revocation | v0.2 | Needs revocation list |
-| Graph view | v0.2 | Needs LLM extraction |
-| Temporal queries | v0.2 | Needs point-in-time reconstruction |
-| Postgres backend | v0.3 | Shipped — `ctxd-store-postgres` (ADR 016) |
-| DuckDB+object-store backend | v0.3 (in flight) | Phase 5B parallel agent |
-| Embedding generation | never | ctxd stores, not generates |
-| EventQL parser | v0.2 | Basic LIKE filter for v0.1 |
-| MCP over SSE/HTTP | v0.2 | stdio only |
+| Full daemon over `dyn Store` for non-SQLite backends | v0.4 | Postgres + DuckDB run a minimal HTTP admin in v0.3 |
+| Token-bucket rate limiting | v0.4 | v0.3 ships a hard 1-second windowed counter (ADR 011) |
+| `budget_refund` for failed downstream ops | v0.4 | Reserve-then-commit semantics today (ADR 011) |
+| Full TEE proof verification | v0.4 | Attestation field is canonicalized; verifier hook is optional (ADR 007) |
+| pgvector / native vector indexes in Postgres | v0.4 | Brute-force cosine fallback today (ADR 016) |
+| Slack, Notion, Linear, calendar adapters | v0.4 | Gmail + GitHub shipped in v0.3 |
+| x402 HTTP 402 gateway integration | v0.4 | `BudgetLimit` enforces locally; HTTP-level micropayments are a separate protocol problem |
+| DuckDB compaction / orphan-Parquet cleanup tool | v0.4 | `ctxd compact` is queued |
+| Embedding generation | never | ctxd stores vectors, doesn't generate them |

--- a/docs/decisions/011-caveat-state-wiring.md
+++ b/docs/decisions/011-caveat-state-wiring.md
@@ -113,6 +113,56 @@ ingestion.
   it would let token holders forge a cheap cost. Costs must be the
   verifier's prerogative.
 
+### 6. Rate-limit state shipped in 0.3.x
+
+The `rate_limit_ops_per_sec(<u32>)` fact has been a token attribute
+since v0.2 but was unenforced — the trait method
+`CaveatState::rate_check` returned `Ok(true)` on every backend. v0.3.x
+ships persistent enforcement on all three backends.
+
+**Design**: a per-`token_id` 1-second windowed counter. On each
+`rate_check(token_id, ops_per_sec)`:
+
+1. Floor `now()` to the start of the current wall-clock second
+   (`window_start`).
+2. Atomically upsert the row: if the stored `window_start` matches the
+   current one, increment `count`; otherwise replace `(window_start,
+   count)` with `(now_floor, 1)`.
+3. Return `count <= ops_per_sec`.
+
+The atomicity is what matters: SQLite uses a transaction-wrapped
+`INSERT … ON CONFLICT(token_id) DO UPDATE` with `CASE` arms inside the
+SET clause; Postgres uses the same shape with `RETURNING count` for a
+single round-trip; the in-memory backend uses a `Mutex<HashMap>`. Two
+concurrent verifies for the same token cannot both observe a
+pre-increment count and both succeed.
+
+**`CapEngine::verify_with_state` runs `rate_check` *last*** —
+after static, budget, and approval caveats have cleared. A
+rate-limited token has otherwise satisfied every check, so the error
+message ("back off and retry") is the only useful one.
+
+**Conditions that would make us revisit**: this is a hard
+sliding-window counter, which means an attacker can (in theory) burst
+2N hits across a 1-millisecond window centered on the second
+boundary. We accept that for v0.3.x because:
+- The hot path for production rate-limiting is still the in-memory
+  fast-path inside `ctxd-cli::rate_limit::RateLimiter`. The DB-backed
+  path exists for multi-process daemons and survives restarts.
+- The error this risks (a brief 2x burst at second boundaries) is
+  preferable to the failure modes of a token-bucket: leaky-bucket
+  state grows per-token-per-window, refill clocks drift across
+  replicas, and admission becomes harder to reason about under
+  partition. The ADR for that rewrite is queued for v0.4 (token
+  bucket with `refill_per_sec` + `bucket_capacity`).
+
+The integration tests in
+`crates/ctxd-cap/tests/rate_limit_enforcement.rs`,
+`crates/ctxd-store-sqlite/tests/rate_limit_persists.rs`, and
+`crates/ctxd-store-postgres/tests/pg_rate_limit.rs` pin the
+admit/deny boundary so a future smoother replacement has a regression
+net.
+
 ## Conditions that would make us revisit
 
 - A user reports billing errors caused by failed-op-still-charged
@@ -122,3 +172,7 @@ ingestion.
 - A second store backend (Postgres) lands: re-confirm the
   atomicity contract on `budget_increment` (it must use
   `UPDATE … RETURNING` or a transaction; SQLite uses the latter).
+- A user reports "I get a brief burst above my rate limit at exactly
+  the wall-clock second boundary": replace the windowed counter with
+  a token bucket per the v0.4 ADR. Until that lands, the
+  `rate_limit_*` integration tests remain the contract.

--- a/docs/plans/v0.3-progress.md
+++ b/docs/plans/v0.3-progress.md
@@ -9,7 +9,7 @@ Updated live as each phase completes. Branch: `worktree-agent-aec7e2dce2475cde8`
 | Baseline (v0.2) | Green | — | 89 tests across workspace pass; clippy clean |
 | 1. Foundation | Green | yes | 1A/1B/1C/1D/1E all landed; trait-object build clean; migrate round-trips on v0.2-shaped DB; ctx_entities/ctx_related/ctx_timeline exercised end-to-end |
 | 2. Federation | Green | yes | 2A wire variants, 2B auto cap-exchange + handshake, 2C biscuit third-party blocks, 2D replication loop with loop guard, 2E cursor resume + parent backfill, 2F LWW convergence test, 2G peer CLI, 2H federation.md + ADRs 006/008/009/010 — all landed |
-| 3. Stateful caveats + MCP transports | Mostly done | yes (3A/3B/3C/3D) | 3A `CaveatState` trait + in-memory + SQLite impls; 3B BudgetLimit enforcement landed (verify_with_state, OperationCost table, ADR 011); 3C HumanApprovalRequired landed (approval_wait + Notify + ctxd approve CLI + POST /v1/approvals/:id/decide + ADR 012); 3D multi-transport MCP landed (stdio + SSE + streamable-HTTP serve the same CtxdMcpServer, `--mcp-sse` / `--mcp-http` / `--require-auth` flags, header-beats-arg auth precedence, 8 integration tests, ADR 013, `http-transports` Cargo feature); 3E rate-limit state still deferred. |
+| 3. Stateful caveats + MCP transports | Green | yes | 3A `CaveatState` trait + in-memory + SQLite impls; 3B BudgetLimit enforcement landed (verify_with_state, OperationCost table, ADR 011); 3C HumanApprovalRequired landed (approval_wait + Notify + ctxd approve CLI + POST /v1/approvals/:id/decide + ADR 012); 3D multi-transport MCP landed (stdio + SSE + streamable-HTTP serve the same CtxdMcpServer, `--mcp-sse` / `--mcp-http` / `--require-auth` flags, header-beats-arg auth precedence, 8 integration tests, ADR 013, `http-transports` Cargo feature); **3E shipped in 0.3.x — persistent windowed-counter rate-limit on InMemory + SQLite + Postgres, wired into `verify_with_state`, new `CapError::RateLimited` variant, ADR 011 updated.** |
 | 4. Embeddings + real adapters + TEE | Green | yes | 4A `ctxd-embed` crate + `Embedder` trait + `NullEmbedder` + real `OpenAiEmbedder` (+ `feature = "openai"`) + `OllamaEmbedder` (+ `feature = "ollama"`) with retry-after + backoff + key-redaction; 4B HNSW persistence via `hnsw_rs` 0.3 with on-disk sidecars + magic precheck + crash-recovery rebuild from `vector_embeddings`; `ctx_search` extended with `search_mode: fts | vector | hybrid` (default hybrid when embedder configured) and Reciprocal Rank Fusion (k=60); 4C Gmail adapter; 4D GitHub adapter; 4E TEE ADR; 4F `docs/embeddings.md` + ADRs 014/015 + README + bench numbers (HNSW 601 µs vs brute 49 ms at N=10k). |
 | 5. Postgres + DuckDB/object-store backends | Green | yes (5A/5B/5C) | 5A `ctxd-store-postgres` shipped: full conformance, concurrent-append + recursive-read + FTS-ranking + idempotency tests, CI matrix entry, `docs/storage-postgres.md`, ADRs 016/017. 5B `ctxd-store-duckobj` shipped: append-only Parquet on object store + WAL + 64MB/5min rotation + atomic manifest + SQLite sidecar for KV/peers/caveats/vectors, full conformance + 6 backend-specific tests (rotation, wal_replay, manifest_atomicity, concurrent_appenders, recursive_read, parents_and_attestation_roundtrip), `docs/storage-duckdb-object.md`, ADR 018. 5C `--storage` CLI selector + `--storage-uri` flag + minimal HTTP admin fallback for non-SQLite backends, `storage-postgres` and `storage-duckdb-object` Cargo features, 3 selector tests, ADR 019. Full daemon over Postgres/DuckDB (federation/MCP/wire over `dyn Store`) queued for v0.4. |
 
@@ -180,14 +180,27 @@ high-level summary.)
   7. `crates/ctxd-http/tests/approval_http_endpoint.rs`
   8. `crates/ctxd-cli/tests/approval_cli_subcommand.rs`
   9. `crates/ctxd-cap/tests/budget_cost_table.rs`
-- **Still deferred** (owned by other agents per the multi-worktree
-  plan):
-  - **3D multi-transport MCP**: SSE + streamable-HTTP. Owner: a
-    different worktree.
-  - **3E rate-limit state**: `CaveatState::rate_check` is still a
-    `true`-returning shim on the SQLite backend. The in-memory
-    fast path in `ctxd-cli::rate_limit::RateLimiter` covers single
-    -process daemons; multi-process rate limiting is a v0.4 item.
+- **3D shipped (multi-transport MCP)**: see Phase 3 entry above.
+- **3E shipped (persistent rate-limit caveat state, v0.3.x)**:
+  `CaveatState::rate_check(token_id, ops_per_sec)` now persists a
+  1-second windowed counter on all three backends.
+  - In-memory: `Mutex<HashMap<token_id, (window_start, count)>>`.
+  - SQLite: new `rate_buckets` table; upsert with `CASE` arms inside
+    the SET clause to reset count on a new window. Schema is gated
+    by `CREATE TABLE IF NOT EXISTS` so existing 0.3.0 databases
+    pick it up at startup with no migration command.
+  - Postgres: new `rate_buckets` table in `0003_caveats.sql`;
+    `INSERT … ON CONFLICT … DO UPDATE` with `RETURNING count` for a
+    single round-trip.
+  - `CapEngine::verify_with_state` calls `rate_check` *last*, after
+    budget and approval caveats. `CapError::RateLimited { ops_per_sec }`
+    surfaces the declared cap so logs make the limit visible.
+  - Tests:
+    `crates/ctxd-cap/tests/rate_limit_enforcement.rs`,
+    `crates/ctxd-store-sqlite/tests/rate_limit_persists.rs`,
+    `crates/ctxd-store-postgres/tests/pg_rate_limit.rs`.
+  - ADR 011 updated with the windowed-counter design + an explicit
+    "Revisit when" clause for the v0.4 token-bucket rewrite.
 
 ### Phase 2 — landed
 


### PR DESCRIPTION
## Summary

Phase 6 — final polish for the autonomous overnight ctxd launch run. Two parts under one PR:

**Part A — persistent rate-limit caveat state (the v0.3 leftover, 3E)**

`CaveatState::rate_check(token_id, ops_per_sec)` is now a real per-token 1-second windowed counter on all three backends:

- **In-memory**: `Mutex<HashMap<token_id, (window_start, count)>>` — was a `Ok(true)` stub.
- **SQLite**: new `rate_buckets` table (additive, gated on `CREATE TABLE IF NOT EXISTS` so existing 0.3.0 databases pick it up at startup with no migration command). Atomic upsert with a `CASE` arm inside the SET clause: same-second hits increment, different-second hits reset count to 1 and roll `window_start` forward.
- **Postgres**: new `rate_buckets` row in `0003_caveats.sql`. Single-statement `INSERT … ON CONFLICT … DO UPDATE … RETURNING count` using `date_trunc('second', $2)` for the window floor.

`CapEngine::verify_with_state` calls `rate_check` *last*, after budget and approval caveats. New `CapError::RateLimited { ops_per_sec }` variant surfaces the declared cap so logs make the limit visible without re-extracting the token.

Three integration suites pin the admit/deny boundary so a future smoother token-bucket replacement has a regression net:
- `crates/ctxd-cap/tests/rate_limit_enforcement.rs`
- `crates/ctxd-store-sqlite/tests/rate_limit_persists.rs`
- `crates/ctxd-store-postgres/tests/pg_rate_limit.rs` (CTXD_PG_URL-gated)

ADR 011 updated with the windowed-counter design and an explicit "Revisit when" clause for the v0.4 token-bucket rewrite.

**Part B — launch-ready docs pass**

- **README.md** — architecture diagram refreshed (three SDKs + API contract artifact + federation peer link); "What's in v0.3" gains the SDK + API-contract + RateLimited rows; new "Build a client" subsection with one-line install + minimal snippet for each SDK (Rust `cargo add ctxd-client`, Python `pip install ctxd-client`, TS `npm i @ctxd/client`); crate map bumped from 14 → 16 (with `ctxd-wire` called out and the three SDKs listed below the workspace); Docs table gains rows for `clients/` and `docs/api/`; test count line updated from `364` → `~425`.
- **docs/architecture.md** — system-overview diagram includes the three MCP transports, the federation peer arrow, the SDKs, and the API contract pin-and-validate relationship; dependency graph rebuilt to show `ctxd-wire` as a leaf; materialized-views table updated for hnsw_rs persistence + Postgres tsvector + graph + temporal views; caveat table includes BudgetLimit, HumanApprovalRequired, RateLimit (with the windowed-counter note), and third-party blocks; SQLite-schema block lists every v0.3 table including `rate_buckets`; new "Client SDKs" subsection; the old "What v0.1 does NOT include" section is replaced with a "What v0.3 does NOT include" block that points at v0.4 ADRs; write-path sequence diagram surfaces the budget/approval/rate-limit branches inside `verify_with_state`.
- **CHANGELOG.md** — new `## v0.3.1 — 2026-04-24` entry block listing the SDK milestone, the `/v1/peers` admin endpoints, the `ctxd-wire` crate split, the API contract artifact, and the persistent rate-limit caveat state.
- **docs/plans/v0.3-progress.md** — Phase 3 status `Mostly done` → `Green`; the resumption-notes block now points at the three new integration suites and the ADR update.

## SDK milestone PRs that landed before this one

- #3 — `ctxd-wire` crate split out of `ctxd-cli`
- #4 — `/v1/peers` admin endpoints
- #5 — API contract artifact + conformance corpus
- #6 — Rust SDK (`ctxd-client` on crates.io)
- #7 — Python SDK (`ctxd-client` on PyPI, imports as `ctxd`)
- #8 — TypeScript SDK (`@ctxd/client` on npm)

## Test plan

- [x] `cargo test --workspace --all-features` — 425 pass, 0 fail across 118 test binaries (locally)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean (locally)
- [x] `cargo fmt --all --check` — clean (locally)
- [x] New integration suites green:
  - [x] `cargo test -p ctxd-cap --test rate_limit_enforcement` — 3 pass
  - [x] `cargo test -p ctxd-store-sqlite --test rate_limit_persists` — 2 pass
  - [ ] `cargo test -p ctxd-store-postgres --test pg_rate_limit` — runs in CI's postgres job
- [ ] Mermaid diagrams in README and architecture.md render without syntax errors on GitHub
- [ ] CHANGELOG v0.3.1 entry follows the existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)