### PR TITLE
Release pipeline: cross-platform binaries + curl|sh + Homebrew tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,16 @@
 name: Release
 
+# Builds the ctxd daemon binary for macOS (arm64 + x86_64) and Linux
+# (x86_64 + aarch64) on every `v*` tag, attaches the tarballs and an
+# install.sh to the GitHub Release, and pushes a Homebrew formula to
+# keeprlabs/homebrew-tap so `brew install keeprlabs/tap/ctxd` works.
+#
+# The release notes for the public-facing release are committed to
+# release-notes/v<version>.md. If that file exists, the workflow uses
+# it verbatim; otherwise it falls back to GitHub's auto-generated
+# notes. This lets us hand-write voice for the announcement releases
+# and still ship patch tags without ceremony.
+
 on:
   push:
     tags:
@@ -13,6 +24,7 @@ jobs:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
@@ -31,38 +43,210 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install cross-compilation tools (linux/aarch64)
         if: matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Build
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --bin ctxd --target ${{ matrix.target }}
         env:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
       - name: Package
+        id: pkg
+        shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../ctxd-${{ matrix.target }}.tar.gz ctxd
-          cd ../../..
+          set -euo pipefail
+          TARGET="${{ matrix.target }}"
+          VERSION="${GITHUB_REF_NAME#v}"
+          STAGE="ctxd-${VERSION}-${TARGET}"
+          mkdir -p "$STAGE"
+          cp "target/${TARGET}/release/ctxd" "$STAGE/ctxd"
+          cp README.md LICENSE "$STAGE/"
+          tar czf "${STAGE}.tar.gz" "$STAGE"
+          # Compute sha256 in a portable way (shasum is on both macOS and ubuntu-latest).
+          shasum -a 256 "${STAGE}.tar.gz" | awk '{print $1}' > "${STAGE}.tar.gz.sha256"
+          echo "tarball=${STAGE}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "checksum=${STAGE}.tar.gz.sha256" >> "$GITHUB_OUTPUT"
+          echo "Built ${STAGE}.tar.gz"
+          echo "sha256: $(cat "${STAGE}.tar.gz.sha256")"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ctxd-${{ matrix.target }}
-          path: ctxd-${{ matrix.target }}.tar.gz
+          path: |
+            ${{ steps.pkg.outputs.tarball }}
+            ${{ steps.pkg.outputs.checksum }}
+          retention-days: 7
 
   release:
-    name: Create Release
+    name: Create GitHub Release
     needs: build
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      sha_x86_64_linux: ${{ steps.checksums.outputs.sha_x86_64_linux }}
+      sha_aarch64_linux: ${{ steps.checksums.outputs.sha_aarch64_linux }}
+      sha_x86_64_darwin: ${{ steps.checksums.outputs.sha_x86_64_darwin }}
+      sha_aarch64_darwin: ${{ steps.checksums.outputs.sha_aarch64_darwin }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@v4
 
-      - name: Create Release
+      - name: Compute release metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Flatten artifacts and gather checksums
+        id: checksums
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          # Each upload-artifact directory contains the tarball + .sha256 sibling.
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.sha256" \) -exec cp {} dist/ \;
+          ls -la dist
+
+          # Read each per-target sha into outputs so the homebrew job can reuse them
+          # without re-downloading. Filenames are deterministic from the matrix.
+          v="${{ steps.meta.outputs.version }}"
+          read_sha() { cat "dist/ctxd-${v}-$1.tar.gz.sha256"; }
+          {
+            echo "sha_x86_64_linux=$(read_sha x86_64-unknown-linux-gnu)"
+            echo "sha_aarch64_linux=$(read_sha aarch64-unknown-linux-gnu)"
+            echo "sha_x86_64_darwin=$(read_sha x86_64-apple-darwin)"
+            echo "sha_aarch64_darwin=$(read_sha aarch64-apple-darwin)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Render install.sh with pinned version
+        run: |
+          set -euo pipefail
+          v="${{ steps.meta.outputs.version }}"
+          # Stamp the version into the installer template so the asset
+          # on the release matches the release exactly. The "UNPINNED"
+          # sentinel (in scripts/install.sh) becomes the literal
+          # version string here. Users who hit
+          # /releases/latest/download/install.sh get the per-release
+          # pinned variant; the unpinned latest-resolving variant is
+          # in scripts/install.sh on main, for the rare case where a
+          # caller needs to track latest deliberately.
+          sed "s/^PINNED_VERSION=\"UNPINNED\"$/PINNED_VERSION=\"${v}\"/" scripts/install.sh > dist/install.sh
+          chmod +x dist/install.sh
+          grep '^PINNED_VERSION=' dist/install.sh
+
+      - name: Resolve release notes
+        id: notes
+        run: |
+          set -euo pipefail
+          v="${{ steps.meta.outputs.version }}"
+          NOTES_FILE="release-notes/v${v}.md"
+          if [ -f "$NOTES_FILE" ]; then
+            echo "Using hand-written notes from $NOTES_FILE"
+            echo "path=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+            echo "use_generated=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No $NOTES_FILE — falling back to GitHub auto-generated notes"
+            echo "path=" >> "$GITHUB_OUTPUT"
+            echo "use_generated=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release (hand-written notes)
+        if: steps.notes.outputs.use_generated == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          files: ctxd-*/ctxd-*.tar.gz
+          files: |
+            dist/ctxd-*.tar.gz
+            dist/ctxd-*.tar.gz.sha256
+            dist/install.sh
+          body_path: ${{ steps.notes.outputs.path }}
+          generate_release_notes: false
+          fail_on_unmatched_files: true
+
+      - name: Create GitHub Release (auto-generated notes)
+        if: steps.notes.outputs.use_generated == 'true'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/ctxd-*.tar.gz
+            dist/ctxd-*.tar.gz.sha256
+            dist/install.sh
           generate_release_notes: true
+          fail_on_unmatched_files: true
+
+  update-homebrew:
+    name: Update Homebrew tap
+    needs: release
+    runs-on: ubuntu-latest
+    # Skip pre-release tags (alpha/beta/rc) — they shouldn't update the
+    # default `brew install` path.
+    if: ${{ !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, 'rc') }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render formula
+        env:
+          VERSION: ${{ needs.release.outputs.version }}
+          SHA_X86_LINUX: ${{ needs.release.outputs.sha_x86_64_linux }}
+          SHA_ARM_LINUX: ${{ needs.release.outputs.sha_aarch64_linux }}
+          SHA_X86_DARWIN: ${{ needs.release.outputs.sha_x86_64_darwin }}
+          SHA_ARM_DARWIN: ${{ needs.release.outputs.sha_aarch64_darwin }}
+        run: |
+          set -euo pipefail
+          # Substitute version + per-platform sha256s into the template.
+          # The template lives in-repo so reviewers can see the formula
+          # change in the same PR as a release-process change.
+          sed \
+            -e "s|__VERSION__|${VERSION}|g" \
+            -e "s|__SHA_X86_LINUX__|${SHA_X86_LINUX}|g" \
+            -e "s|__SHA_ARM_LINUX__|${SHA_ARM_LINUX}|g" \
+            -e "s|__SHA_X86_DARWIN__|${SHA_X86_DARWIN}|g" \
+            -e "s|__SHA_ARM_DARWIN__|${SHA_ARM_DARWIN}|g" \
+            homebrew/ctxd.rb.tmpl > /tmp/ctxd.rb
+          echo "── rendered formula ──"
+          cat /tmp/ctxd.rb
+
+      - name: Push to homebrew-tap
+        env:
+          TAP_DEPLOY_KEY: ${{ secrets.TAP_DEPLOY_KEY }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -z "${TAP_DEPLOY_KEY:-}" ]; then
+            echo "::warning::TAP_DEPLOY_KEY is not configured. Skipping tap update."
+            echo "To enable: add a deploy key with write access to keeprlabs/homebrew-tap"
+            echo "and store its private key as TAP_DEPLOY_KEY in this repo's secrets."
+            exit 0
+          fi
+          mkdir -p ~/.ssh
+          echo "$TAP_DEPLOY_KEY" > ~/.ssh/tap_key
+          chmod 600 ~/.ssh/tap_key
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/tap_key -o StrictHostKeyChecking=no"
+
+          git clone git@github.com:keeprlabs/homebrew-tap.git /tmp/homebrew-tap
+          cd /tmp/homebrew-tap
+          mkdir -p Formula
+          cp /tmp/ctxd.rb Formula/ctxd.rb
+
+          git config user.name "ctxd-release-bot"
+          git config user.email "bot@keeprlabs.org"
+          git add Formula/ctxd.rb
+          if git diff --cached --quiet; then
+            echo "No formula changes to commit"
+            exit 0
+          fi
+          git commit -m "ctxd ${VERSION}"
+          git push origin main
+          echo "Published ctxd ${VERSION} to keeprlabs/homebrew-tap"

--- a/homebrew/README.md
+++ b/homebrew/README.md
@@ -1,0 +1,61 @@
+# Homebrew formula for ctxd
+
+This directory holds the Homebrew formula template for `ctxd`. The
+release workflow renders it with the new version + per-platform
+sha256s and pushes the result to
+[`keeprlabs/homebrew-tap`](https://github.com/keeprlabs/homebrew-tap)
+as `Formula/ctxd.rb`.
+
+## Install
+
+```bash
+brew install keeprlabs/tap/ctxd
+```
+
+That installs the `ctxd` binary to `/opt/homebrew/bin/ctxd` (Apple
+Silicon) or `/usr/local/bin/ctxd` (Intel Mac, Linuxbrew).
+
+## Update
+
+```bash
+brew upgrade ctxd
+```
+
+## Uninstall
+
+```bash
+brew uninstall ctxd
+```
+
+## Why a formula and not a cask?
+
+`ctxd` is a single CLI binary, not a `.app` bundle, so it ships as a
+formula. Casks are for GUI applications.
+
+## Release-time mechanics
+
+`homebrew/ctxd.rb.tmpl` is the template. The release workflow does:
+
+1. Builds tarballs for the four supported targets (macOS arm64 +
+   x86_64, Linux x86_64 + aarch64).
+2. Uploads each tarball plus its `.sha256` sibling to the GitHub
+   release for the tag.
+3. Substitutes `__VERSION__` and `__SHA_*__` placeholders into the
+   template.
+4. Clones `keeprlabs/homebrew-tap` over SSH using the `TAP_DEPLOY_KEY`
+   secret, copies the rendered file to `Formula/ctxd.rb`, commits,
+   and pushes.
+
+## Setup (one-time, already done)
+
+For posterity:
+
+1. The `keeprlabs/homebrew-tap` repo has a deploy key with write
+   access named `ctxd-tap-deploy`.
+2. The matching private key is stored in this repo's secrets as
+   `TAP_DEPLOY_KEY`.
+3. The release workflow's `update-homebrew` job uses that key to
+   push.
+
+If `TAP_DEPLOY_KEY` is missing, the job logs a warning and exits
+cleanly — releases still publish, the tap just doesn't update.

--- a/homebrew/ctxd.rb.tmpl
+++ b/homebrew/ctxd.rb.tmpl
@@ -1,0 +1,52 @@
+# Homebrew formula for ctxd — context substrate for AI agents.
+#
+# This formula is rendered from homebrew/ctxd.rb.tmpl by
+# .github/workflows/release.yml on every `v*` tag and pushed to
+# keeprlabs/homebrew-tap as Formula/ctxd.rb.
+#
+# Install:
+#   brew install keeprlabs/tap/ctxd
+class Ctxd < Formula
+  desc "Context substrate for AI agents — single-binary daemon, append-only event log, capabilities, MCP-native"
+  homepage "https://github.com/keeprlabs/ctxd"
+  version "__VERSION__"
+  license "Apache-2.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/keeprlabs/ctxd/releases/download/v#{version}/ctxd-#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "__SHA_ARM_DARWIN__"
+    end
+    on_intel do
+      url "https://github.com/keeprlabs/ctxd/releases/download/v#{version}/ctxd-#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "__SHA_X86_DARWIN__"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/keeprlabs/ctxd/releases/download/v#{version}/ctxd-#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "__SHA_ARM_LINUX__"
+    end
+    on_intel do
+      url "https://github.com/keeprlabs/ctxd/releases/download/v#{version}/ctxd-#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "__SHA_X86_LINUX__"
+    end
+  end
+
+  def install
+    bin.install "ctxd-#{version}-#{stage_target}/ctxd"
+  end
+
+  def stage_target
+    if OS.mac?
+      Hardware::CPU.arm? ? "aarch64-apple-darwin" : "x86_64-apple-darwin"
+    else
+      Hardware::CPU.arm? ? "aarch64-unknown-linux-gnu" : "x86_64-unknown-linux-gnu"
+    end
+  end
+
+  test do
+    assert_match "ctxd", shell_output("#{bin}/ctxd --version")
+  end
+end

--- a/release-notes/v0.3.0.md
+++ b/release-notes/v0.3.0.md
@@ -1,0 +1,133 @@
+# ctxd v0.3.0 — initial public release
+
+ctxd is a context substrate for AI agents. One binary, an append-only event log, subject-based addressing, capability tokens, federation between trusted nodes, and a native MCP server. Not a vector DB, not an agent framework, not a knowledge graph — a substrate the rest of those things plug into.
+
+This is the first public release. The daemon is feature-complete for v0.3 and ships with three first-party SDKs (Rust, Python, TypeScript) that pin to the same conformance corpus as the daemon itself.
+
+## Why this exists
+
+Every agent session starts with amnesia. Context is scattered across mailboxes, code hosts, chat logs, and whatever a teammate typed into a chat window an hour ago. Each tool has its own siloed view, none of them talk to each other, and each new agent re-derives state from scratch. ctxd is one place where that context lives, addressed by subject paths, secured by capability tokens, queryable by any agent over MCP, and replicated to peer nodes you trust. Write once, query from anywhere, prove what was written.
+
+The whole log is tamper-evident (predecessor hash chains, Ed25519 signatures), the views are derived (and rebuildable from the log), and capabilities are bearer + attenuable + offline-verifiable. See [`docs/architecture.md`](https://github.com/keeprlabs/ctxd/blob/main/docs/architecture.md) and the 19 ADRs in [`docs/decisions/`](https://github.com/keeprlabs/ctxd/tree/main/docs/decisions) for the design choices.
+
+## What's in this release
+
+**Daemon.** A single `ctxd` binary speaks HTTP admin (port 7777), the MessagePack wire protocol (port 7778), and three MCP transports (stdio + SSE + streamable HTTP) — concurrently, off the same tool surface. Eight MCP tools: `ctx_write`, `ctx_read`, `ctx_subjects`, `ctx_search`, `ctx_subscribe`, `ctx_entities`, `ctx_related`, `ctx_timeline`.
+
+**Three storage backends** behind one `Store` trait + conformance suite.
+
+- SQLite (default; full daemon)
+- Postgres (clustered FTS via `tsvector`, advisory-lock TOCTOU)
+- DuckDB-on-object-store (Parquet on S3 / R2 / Azure / GCS / local fs + SQLite sidecar)
+
+Postgres and DuckDB run a minimal HTTP admin today; the full daemon over `Arc<dyn Store>` is the headline item for v0.4.
+
+**Federation.** Two ctxd nodes peer with one command, bidirectionally replicate the subjects you grant, resume from persisted cursors after a restart, backfill missing parents on causal-DAG gaps, and resolve concurrent writes with deterministic LWW on `(time, event_id)`. Replication runs at ~1500 events/sec on localhost TCP; biscuit third-party block verification is ~415 µs.
+
+**Capabilities** are biscuit tokens with stateful caveats:
+
+- `BudgetLimit` — per-token spend ceiling; reserve-then-commit semantics (ADR 011)
+- `HumanApprovalRequired` — verifier blocks until `ctxd approve` or `POST /v1/approvals/:id/decide` (ADR 012)
+- `RateLimited` — persistent 1-second windowed counter on every backend (in-memory, SQLite, Postgres)
+
+**Real ingestion adapters.** Gmail (OAuth2 device flow + AES-256-GCM token at rest + History API incremental sync). GitHub (PAT + ETag caching + primary and secondary rate-limit handling).
+
+**Hybrid search.** Pluggable embedders (`OpenAiEmbedder`, `OllamaEmbedder`, `NullEmbedder`), HNSW vector index persisted via `hnsw_rs` with crash-recovery rebuild from the source log, and Reciprocal Rank Fusion across FTS + vector. At N=10k: HNSW 601 µs vs brute-force 49 ms (~82× speedup), hybrid 3.3 ms.
+
+**Three first-party SDKs**, each pinned to the same [`docs/api/`](https://github.com/keeprlabs/ctxd/tree/main/docs/api) contract:
+
+- Rust — [`ctxd-client`](https://github.com/keeprlabs/ctxd/blob/main/clients/rust/ctxd-client/README.md) (`cargo add ctxd-client`)
+- Python — [`ctxd-client`](https://github.com/keeprlabs/ctxd/blob/main/clients/python/ctxd-py/README.md), imports as `ctxd` (`pip install ctxd-client`)
+- TypeScript — [`@ctxd/client`](https://github.com/keeprlabs/ctxd/blob/main/clients/typescript/ctxd-client/README.md) (`npm i @ctxd/client`)
+
+All three run the same MessagePack hex fixtures and JSON Schema corpus the daemon runs.
+
+**425 tests** across the workspace, clippy-clean, fmt-clean, and a Postgres conformance job in CI against `postgres:16`.
+
+## Install
+
+### Homebrew (macOS, Linux)
+
+```bash
+brew install keeprlabs/tap/ctxd
+```
+
+### curl | sh
+
+```bash
+curl -fsSL https://github.com/keeprlabs/ctxd/releases/latest/download/install.sh | sh
+```
+
+The installer auto-detects your OS and architecture, verifies the published sha256, and drops the binary in the first writable directory it finds on `$PATH` (preferring `~/.local/bin`, then `~/.cargo/bin`, then `/usr/local/bin`). Override with `CTXD_INSTALL_DIR=/some/where`.
+
+### Manual
+
+Grab the tarball for your target from the assets below. Each tarball ships with a `.sha256` sibling so you can verify before extracting.
+
+| Target | Tarball |
+|---|---|
+| macOS arm64 | `ctxd-0.3.0-aarch64-apple-darwin.tar.gz` |
+| macOS x86_64 | `ctxd-0.3.0-x86_64-apple-darwin.tar.gz` |
+| Linux x86_64 | `ctxd-0.3.0-x86_64-unknown-linux-gnu.tar.gz` |
+| Linux arm64 | `ctxd-0.3.0-aarch64-unknown-linux-gnu.tar.gz` |
+
+### From source
+
+```bash
+git clone https://github.com/keeprlabs/ctxd && cd ctxd
+cargo build --release
+# Add --features storage-postgres,storage-duckdb-object for the heavier backends.
+```
+
+## 60-second quickstart
+
+```bash
+# Start the daemon (SQLite + stdio MCP).
+ctxd serve
+
+# In another terminal:
+ctxd write --subject /work/acme/notes/standup --type ctx.note \
+  --data '{"content":"Ship auth by Friday"}'
+ctxd read --subject /work/acme --recursive
+ctxd grant --subject "/work/acme/**" --operations "read,subjects"
+```
+
+Then point Claude Desktop at it:
+
+```json
+{
+  "mcpServers": {
+    "ctxd": {
+      "command": "/path/to/ctxd",
+      "args": ["serve", "--mcp-stdio"]
+    }
+  }
+}
+```
+
+For semantic search:
+
+```bash
+export OPENAI_API_KEY=sk-...
+ctxd serve --embedder openai
+```
+
+For federation, see [`docs/federation.md`](https://github.com/keeprlabs/ctxd/blob/main/docs/federation.md). For Postgres or DuckDB+S3, see [`docs/storage-postgres.md`](https://github.com/keeprlabs/ctxd/blob/main/docs/storage-postgres.md) and [`docs/storage-duckdb-object.md`](https://github.com/keeprlabs/ctxd/blob/main/docs/storage-duckdb-object.md).
+
+## Known limitations
+
+- **Full daemon over Postgres / DuckDB is deferred to v0.4.** Both backends run today, both pass the full conformance suite, but the federation loop, the MCP transports, and the wire server still talk to a concrete `EventStore` (SQLite). Operators who pick Postgres or DuckDB get the HTTP admin and the storage substrate, not yet the rest. ADR 019 spells out why and what's next.
+- **No pgvector yet** — Postgres FTS is shipped, vector lives in `BYTEA` with a brute-force cosine match for now. ADR 016 calls this out.
+- **TEE attestation rides through canonical form**, but full proof verification (the verifier hook) lands in v0.4. ADR 007.
+- **Adapter coverage is intentionally narrow.** Gmail and GitHub are real and tested; Slack / Notion / Linear / calendar are queued. The adapter trait is stable — see [`docs/adapter-guide.md`](https://github.com/keeprlabs/ctxd/blob/main/docs/adapter-guide.md) if you want to write one.
+- **No `ctxd compact` yet** for DuckDB orphan-Parquet cleanup.
+
+## What's next (v0.4)
+
+Full daemon over `Arc<dyn Store>`. pgvector. TEE proof verification. Slack, Notion, Linear adapters. Token-bucket rate limit (the windowed counter is the conservative-correct version that ships today; ADR 011 has the design notes). x402 HTTP 402 gateway integration.
+
+## Thanks
+
+Special thanks to everyone who used a private build during the internal bake — every report sharpened the trait boundaries and tightened the conformance corpus. The Rust SDK is the source of truth, the Python and TypeScript SDKs mirror it byte-for-byte, and that discipline came out of those reviews.
+
+Issues and PRs welcome at [keeprlabs/ctxd](https://github.com/keeprlabs/ctxd).

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env sh
+# ctxd installer.
+#
+# Usage:
+#   curl -fsSL https://github.com/keeprlabs/ctxd/releases/latest/download/install.sh | sh
+#   curl -fsSL https://github.com/keeprlabs/ctxd/releases/download/v0.3.0/install.sh | sh
+#
+# What it does:
+#   1. Detects your OS + architecture.
+#   2. Downloads the matching release tarball from GitHub.
+#   3. Verifies the published sha256.
+#   4. Extracts the `ctxd` binary into a directory on your $PATH
+#      (preferring an existing directory you can write to, falling
+#      back to ~/.local/bin and asking you to add it to PATH).
+#
+# Override the install location with CTXD_INSTALL_DIR, e.g.:
+#   curl -fsSL .../install.sh | CTXD_INSTALL_DIR=/usr/local/bin sh
+#
+# This script is rendered with a pinned version baked in at release
+# time; the placeholder below is replaced by the release workflow.
+# A copy without the pinned version is also published as the "latest"
+# install.sh — that variant resolves the latest tag at run-time.
+
+set -eu
+
+REPO="keeprlabs/ctxd"
+# `PINNED_VERSION` is rewritten by the release workflow so a per-tag
+# install.sh ships pinned to that exact version. The "latest" copy in
+# the repo keeps the UNPINNED sentinel and resolves the version from
+# the GitHub /releases/latest redirect at run time.
+PINNED_VERSION="UNPINNED"
+
+err() { printf 'ctxd-install: %s\n' "$*" >&2; exit 1; }
+info() { printf 'ctxd-install: %s\n' "$*"; }
+
+# ── version resolution ─────────────────────────────────────────────────
+
+resolve_version() {
+  if [ "$PINNED_VERSION" != "UNPINNED" ]; then
+    printf '%s' "$PINNED_VERSION"
+    return
+  fi
+  # Latest tag from the GitHub redirect — no auth, no jq.
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSLI -o /dev/null -w '%{url_effective}' \
+      "https://github.com/${REPO}/releases/latest" \
+      | sed -E 's|.*/tag/v?([^/]+)$|\1|'
+  elif command -v wget >/dev/null 2>&1; then
+    wget --max-redirect=10 --server-response -q -O /dev/null \
+      "https://github.com/${REPO}/releases/latest" 2>&1 \
+      | awk '/Location:/ {url=$2} END {sub(/.*\/tag\/v?/,"",url); print url}'
+  else
+    err "need curl or wget to resolve latest version"
+  fi
+}
+
+# ── platform detection ─────────────────────────────────────────────────
+
+detect_target() {
+  uname_s="$(uname -s)"
+  uname_m="$(uname -m)"
+  case "$uname_s" in
+    Linux) os="unknown-linux-gnu" ;;
+    Darwin) os="apple-darwin" ;;
+    *) err "unsupported OS: $uname_s (only Linux + macOS for now)" ;;
+  esac
+  case "$uname_m" in
+    x86_64|amd64) arch="x86_64" ;;
+    aarch64|arm64) arch="aarch64" ;;
+    *) err "unsupported architecture: $uname_m" ;;
+  esac
+  printf '%s-%s' "$arch" "$os"
+}
+
+# ── install location ───────────────────────────────────────────────────
+
+# Pick the first directory we can actually write to. Honour explicit
+# CTXD_INSTALL_DIR when set. We deliberately avoid sudo: an installer
+# that silently escalates is a bad neighbour.
+pick_install_dir() {
+  if [ -n "${CTXD_INSTALL_DIR:-}" ]; then
+    printf '%s' "$CTXD_INSTALL_DIR"
+    return
+  fi
+  for d in "$HOME/.local/bin" "$HOME/.cargo/bin" "/usr/local/bin"; do
+    if [ -d "$d" ] && [ -w "$d" ]; then
+      printf '%s' "$d"
+      return
+    fi
+  done
+  # Fall back to creating ~/.local/bin.
+  mkdir -p "$HOME/.local/bin"
+  printf '%s' "$HOME/.local/bin"
+}
+
+# ── download + verify ──────────────────────────────────────────────────
+
+fetch() {
+  url="$1"
+  out="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL --proto '=https' --tlsv1.2 -o "$out" "$url"
+  else
+    wget --https-only -qO "$out" "$url"
+  fi
+}
+
+verify_sha() {
+  archive="$1"
+  expected="$2"
+  if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$archive" | awk '{print $1}')"
+  else
+    err "neither shasum nor sha256sum found — cannot verify download"
+  fi
+  if [ "$actual" != "$expected" ]; then
+    err "sha256 mismatch: expected $expected, got $actual"
+  fi
+}
+
+# ── main ───────────────────────────────────────────────────────────────
+
+main() {
+  version="$(resolve_version)"
+  [ -n "$version" ] || err "could not resolve version"
+  target="$(detect_target)"
+  install_dir="$(pick_install_dir)"
+
+  info "version:     v${version}"
+  info "target:      ${target}"
+  info "install_dir: ${install_dir}"
+
+  base="https://github.com/${REPO}/releases/download/v${version}"
+  archive_name="ctxd-${version}-${target}.tar.gz"
+  archive_url="${base}/${archive_name}"
+  sha_url="${base}/${archive_name}.sha256"
+
+  tmp="$(mktemp -d 2>/dev/null || mktemp -d -t ctxd-install)"
+  trap 'rm -rf "$tmp"' EXIT INT TERM
+
+  info "downloading ${archive_url}"
+  fetch "$archive_url" "$tmp/$archive_name"
+  fetch "$sha_url" "$tmp/$archive_name.sha256"
+
+  expected_sha="$(awk '{print $1}' "$tmp/$archive_name.sha256")"
+  verify_sha "$tmp/$archive_name" "$expected_sha"
+  info "checksum verified"
+
+  tar -xzf "$tmp/$archive_name" -C "$tmp"
+  binary_path="$tmp/ctxd-${version}-${target}/ctxd"
+  [ -f "$binary_path" ] || err "binary not found in archive at expected path"
+
+  install -m 0755 "$binary_path" "$install_dir/ctxd"
+  info "installed: $install_dir/ctxd"
+
+  case ":$PATH:" in
+    *":$install_dir:"*) ;;
+    *)
+      info ""
+      info "note: $install_dir is not on your \$PATH."
+      info "      add this to your shell profile to fix:"
+      info "        export PATH=\"$install_dir:\$PATH\""
+      ;;
+  esac
+
+  info ""
+  info "verify with:  ctxd --version"
+  info "get started:  ctxd serve"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Extends `.github/workflows/release.yml` so every `v*` tag publishes sha256-verified tarballs for the four supported targets (macOS arm64 + x86_64, Linux x86_64 + aarch64), a pinned `install.sh` asset, and pushes a rendered Homebrew formula to `keeprlabs/homebrew-tap` as `Formula/ctxd.rb`.
- Adds `scripts/install.sh` — `curl | sh` installer with arch detection, sha256 verification, PATH-aware install dir picking, and no silent sudo.
- Adds `homebrew/ctxd.rb.tmpl` — formula template covering all four targets via `on_macos` / `on_linux` / `on_arm` / `on_intel` blocks.
- Adds `release-notes/v<x>.md` convention — when the file exists, the workflow uses it verbatim; otherwise it falls back to GitHub auto-generated notes. Initial entry: `release-notes/v0.3.0.md`.

## Mechanics

- The `TAP_DEPLOY_KEY` secret is set on this repo (private SSH key); a matching deploy key with write access (`ctxd-tap-deploy`) is registered on `keeprlabs/homebrew-tap`.
- If the secret is ever absent, the `update-homebrew` job logs a warning and exits 0 — the GitHub Release still publishes; only the tap update is skipped.
- Pre-release tags (`*alpha*`, `*beta*`, `*rc*`) skip the tap update entirely so they don't replace stable.

## Test plan

- [x] Local `cargo build --release --bin ctxd` is green on this host (4m 37s).
- [x] `sh -n scripts/install.sh` parses; the rendered (post-sed) variant also parses and pins the version correctly.
- [x] `ruby -c` on the rendered formula passes.
- [ ] First real test is the `v0.3.0` tag itself — if any matrix build, sha computation, or tap push breaks, fix forward and retag.