### PR TITLE
fix(homebrew): drop unpacked-dir prefix from install path

### DIFF
--- a/homebrew/ctxd.rb.tmpl
+++ b/homebrew/ctxd.rb.tmpl
@@ -35,15 +35,10 @@ class Ctxd < Formula
   end
 
   def install
-    bin.install "ctxd-#{version}-#{stage_target}/ctxd"
-  end
-
-  def stage_target
-    if OS.mac?
-      Hardware::CPU.arm? ? "aarch64-apple-darwin" : "x86_64-apple-darwin"
-    else
-      Hardware::CPU.arm? ? "aarch64-unknown-linux-gnu" : "x86_64-unknown-linux-gnu"
-    end
+    # Each tarball contains a single top-level dir (ctxd-<version>-<target>/);
+    # Homebrew cd's into it before calling `install`, so the binary is at "ctxd"
+    # relative to the working directory.
+    bin.install "ctxd"
   end
 
   test do


### PR DESCRIPTION
## The bug

`brew install keeprlabs/tap/ctxd` failed for v0.3.0 with:

\`\`\`
Error: An exception occurred within a child process:
  Errno::ENOENT: No such file or directory - ctxd-0.3.0-aarch64-apple-darwin/ctxd
\`\`\`

## The cause

Homebrew automatically \`cd\`s into a tarball's single top-level directory before invoking \`def install\`. Our tarballs have one top-level dir (\`ctxd-<version>-<target>/\`), so by the time \`install\` runs, the working dir is already inside it. Referencing \`ctxd-#{version}-#{stage_target}/ctxd\` doubled the path → ENOENT.

## The fix

\`bin.install "ctxd"\` — the binary is at the working-dir root. Also dropped the now-unused \`stage_target\` helper.

## Verification

- Re-rendered \`Formula/ctxd.rb\` in \`keeprlabs/homebrew-tap\` with this change ([commit](https://github.com/keeprlabs/homebrew-tap/commit/6cfc5cc)).
- \`brew install keeprlabs/tap/ctxd\` now succeeds: \`/opt/homebrew/bin/ctxd -> ../Cellar/ctxd/0.3.0/bin/ctxd\`, \`ctxd --version\` prints \`ctxd 0.3.0\`.

## Why no v0.3.1

The bug was formula-only — the published binaries are correct. Patching the deployed tap fixed v0.3.0 immediately; this PR keeps the template in sync so v0.3.1+ doesn't regress.

## Note for next release

The release pipeline doesn't actually \`brew install\` the rendered formula in CI, which is why this slipped past. Reasonable v0.4 follow-up: add a step that runs \`brew install --build-from-source /tmp/ctxd.rb\` against the just-published assets before pushing to the tap, and fail the release if it can't symlink \`ctxd\`.