### PR TITLE
ci: free disk space on the check job to fix runner-resource failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,24 @@ jobs:
     name: Check, Test, Lint
     runs-on: ubuntu-latest
     steps:
+      # Free ~30 GB of unused pre-installed tooling on ubuntu-latest before
+      # the cargo build. With clippy --all-features + cargo test --all + a
+      # release build all sharing the same target/, the default ~14 GB of
+      # free space is too tight: we hit "No space left on device" on tempdir
+      # creation and SIGBUS during linking under memory pressure. Removing
+      # dotnet/android/ghc/codeql/docker images we don't use gives the cargo
+      # steps room to breathe without touching what the build actually needs.
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: false
+
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## The failure

PR #12's CI hit two different failures back-to-back on the **Check, Test, Lint** job:

\`\`\`
attempt 1: error: couldn't create a temp dir: No space left on device (os error 28)
           error: could not compile \`ctxd-store-postgres\` (lib test)
attempt 2: collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
\`\`\`

Both are symptoms of the same root cause: \`ubuntu-latest\` runners have ~14 GB of free disk after the pre-installed tooling, and our check job is too tight against that:

1. \`Swatinem/rust-cache@v2\` restores **1.66 GB** of cargo cache.
2. \`cargo clippy --all-targets --all-features\` builds proc-macros + every feature.
3. \`cargo test --all\` builds a separate set of test binaries (different cfg from check).
4. \`cargo build --release\` builds yet another set with optimizations on.

All sharing one \`target/\`. Linking SIGBUS under memory pressure is the same disease — the runner runs out of address space for the linker once swap fills.

## The fix

Add [\`jlumbroso/free-disk-space@v1.3.1\`](https://github.com/jlumbroso/free-disk-space) as the first step. Removes ~30 GB of pre-installed tooling we don't use:

- dotnet (~2 GB)
- android SDK (~10 GB)
- GHC / Haskell (~5 GB)
- /opt/hostedtoolcache (Python preinstalls, Node preinstalls, Go, Ruby — ~5 GB)
- pre-pulled docker images (~3 GB)

Skipped:

- \`large-packages\` (gcc/llvm — ~5 minutes to remove, small payoff per release-budget tradeoff)
- \`swap-storage\` (preserving GitHub's default swap)

## Scope

Only touches the \`check\` job. The \`postgres\` job and the SDK jobs build narrower crate subsets and have not hit the limit yet.

## Verifying

This PR's own \`Check, Test, Lint\` run *is* the verification — same workspace, same step ordering, with the fix.