### PR TITLE
fix(cli): route tracing output to stderr so MCP stdio stays clean

### DIFF
--- a/crates/ctxd-cli/src/main.rs
+++ b/crates/ctxd-cli/src/main.rs
@@ -1119,7 +1119,7 @@ impl Drop for OtelGuard {
 /// Otherwise only the plain fmt layer is used (zero OTEL overhead).
 fn init_tracing() -> OtelGuard {
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let fmt_layer = tracing_subscriber::fmt::layer();
+    let fmt_layer = tracing_subscriber::fmt::layer().with_writer(std::io::stderr);
 
     if std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT").is_ok() {
         // Build OTLP exporter and tracer provider.


### PR DESCRIPTION
## Summary

- `ctxd serve --mcp-stdio` speaks JSON-RPC over stdout, but `tracing_subscriber::fmt::layer()` defaults to stdout as well. Every log line — including bridged `log::info!` calls from third-party libs like `hnsw_rs` — was being interleaved into the JSON-RPC stream and rejected by MCP clients.
- One-line fix: `.with_writer(std::io::stderr)` on the fmt layer in `init_tracing()`. Stdout now stays exclusively for protocol frames; all tracing goes to stderr.

## Symptom this fixes

When wiring ctxd into Claude Desktop, the MCP server fails to initialize with errors like:

> MCP ctxd: Unexpected token 'E', " End of dum"... is not valid JSON
> MCP ctxd: Unexpected end of JSON input
> MCP ctxd: Unexpected token ' ', " [2m2026-0"... is not valid JSON

The `[2m` is the ANSI dim color code from tracing-subscriber's default formatter; "End of dum" is `hnsw_rs`'s "End of dump" log line. Both were being framed as JSON-RPC messages by the client.

## Verification

- Before: `cargo run --release -- serve --mcp-stdio --db /tmp/test.db </dev/null >stdout.log 2>stderr.log` — stdout has all log lines.
- After: same command — 0 lines on stdout, 38+ on stderr, MCP client connects cleanly.
- End-to-end smoke: Claude Desktop now lists the five `ctx_*` tools without errors and successfully calls `ctx_subjects`, `ctx_search`, and `ctx_write`.

## Scope and tradeoffs

- Affects every ctxd subcommand, not just `serve --mcp-stdio`. Stderr is the correct default for diagnostics in any process that might be piped — no behavioral regression for `write`/`read`/`query`/`subjects` since their structured output already goes to stdout intentionally.
- Both the OTEL and non-OTEL branches of `init_tracing` use the same `fmt_layer`, so the fix applies uniformly.

## Known follow-up (not in this PR)

`hnsw_rs` has bare `println!` calls at `hnsw.rs:520` (fires every 50k points during bulk insert) and `hnsw.rs:780` (>256 max_nb_connection error path). With default settings these don't trigger, but they remain the only stdout leak for very large MCP sessions. Worth a follow-up issue.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] Manual smoke: `ctxd serve --mcp-stdio` redirected to logfiles confirms stdout/stderr separation
- [x] Manual smoke: Claude Desktop integration listing tools and executing `ctx_subjects`/`ctx_search`/`ctx_write` round-trips