### PR TITLE
feat(dashboard): event detail view (click to read what's in an event)

### DIFF
--- a/crates/ctxd-dashboard/assets/app.js
+++ b/crates/ctxd-dashboard/assets/app.js
@@ -89,6 +89,7 @@
     subjects: renderSubjects,
     search: renderSearch,
     peers: renderPeers,
+    event: renderEvent,
   };
 
   let currentRoute = null;
@@ -97,13 +98,15 @@
   function parseRoute() {
     const hash = location.hash.replace(/^#\/?/, '') || '';
     const [path, query] = hash.split('?');
-    const route = path.split('/')[0] || 'overview';
+    const segments = path.split('/').filter(Boolean);
+    const route = segments[0] || 'overview';
+    const rest = segments.slice(1);
     const params = new URLSearchParams(query || '');
-    return { route, params };
+    return { route, rest, params };
   }
 
   function navigate() {
-    const { route, params } = parseRoute();
+    const { route, rest, params } = parseRoute();
     if (currentCleanup) {
       currentCleanup();
       currentCleanup = null;
@@ -116,7 +119,7 @@
     });
     const main = $('#main');
     main.innerHTML = '<p class="loading">loading…</p>';
-    Promise.resolve(renderer(main, params)).catch((err) => {
+    Promise.resolve(renderer(main, params, rest)).catch((err) => {
       main.innerHTML = '';
       main.append(errorPanel(`failed to render ${route}`, err));
     });
@@ -442,6 +445,90 @@
         el('span', { class: 'ty' }, hit.type || ''),
         el('span', { class: 'sub' }, hit.subject)),
       el('div', { class: 'snippet', html: renderSnippet(hit.snippet) }));
+  }
+
+  // ───────── Event detail view ─────────
+  //
+  // Renders /v1/events/<id>. Lead with the actual content (the
+  // memory you wrote), then metadata + signature/parents/attestation
+  // for the technically curious. Hash route: #/event/<id>.
+
+  async function renderEvent(main, _params, rest) {
+    main.innerHTML = '';
+    const id = rest[0];
+    if (!id) {
+      main.append(errorPanel('no event id', new Error('expected #/event/<id>')));
+      return;
+    }
+
+    const back = el('a', { class: 'event-back', href: 'javascript:history.back()' },
+      '← back');
+    main.append(back);
+
+    let event;
+    try {
+      event = await api(`/v1/events/${encodeURIComponent(id)}`);
+    } catch (e) {
+      if (e.status === 404) {
+        main.append(emptyMsg('event not found',
+          `no event with id ${id}. it may have been from a different database, or the id may be malformed.`));
+      } else {
+        main.append(errorPanel('couldn\'t load event', e));
+      }
+      return;
+    }
+
+    // Headline: the content. data.content for ctx.note / ctx.fact /
+    // etc.; falls back to pretty-printed JSON for events that don't
+    // follow that convention.
+    const contentHost = el('div', { class: 'event-content' });
+    const content = event.data && typeof event.data === 'object'
+      ? event.data.content
+      : null;
+    if (typeof content === 'string' && content.length > 0) {
+      contentHost.append(el('pre', { class: 'event-text' }, content));
+    } else {
+      // No `content` field — show the whole `data` blob.
+      contentHost.append(el('pre', { class: 'event-json' }, prettyJson(event.data)));
+    }
+    main.append(panel('Content', contentHost));
+
+    // Metadata table (subject, type, time, source).
+    const meta = el('dl', { class: 'event-meta' });
+    addMetaRow(meta, 'subject', event.subject);
+    addMetaRow(meta, 'type', event.type || event.event_type);
+    addMetaRow(meta, 'time', `${event.time} (${fmtTime(event.time)})`);
+    if (event.source) addMetaRow(meta, 'source', event.source);
+    addMetaRow(meta, 'id', event.id);
+    main.append(panel('Metadata', meta));
+
+    // Provenance: predecessor hash, parents, signature, attestation.
+    // Most events have these blank or null; only render the section
+    // if at least one is set so we don't waste vertical space.
+    const provHost = el('dl', { class: 'event-meta' });
+    let hasProv = false;
+    if (event.predecessorhash) { addMetaRow(provHost, 'predecessor', event.predecessorhash); hasProv = true; }
+    if (event.parents && event.parents.length) { addMetaRow(provHost, 'parents', event.parents.join(', ')); hasProv = true; }
+    if (event.signature) { addMetaRow(provHost, 'signature', event.signature); hasProv = true; }
+    if (event.attestation) { addMetaRow(provHost, 'attestation', `${event.attestation.length} bytes`); hasProv = true; }
+    if (hasProv) main.append(panel('Provenance', provHost));
+
+    // Raw JSON, collapsed by default — for the "I trust nothing,
+    // show me the wire form" power user.
+    const detail = el('details', { class: 'event-raw' },
+      el('summary', {}, 'raw event JSON'),
+      el('pre', { class: 'event-json' }, prettyJson(event)));
+    main.append(panel('Raw', detail));
+  }
+
+  function addMetaRow(dl, label, value) {
+    dl.append(el('dt', {}, label));
+    dl.append(el('dd', {}, String(value == null ? '' : value)));
+  }
+
+  function prettyJson(v) {
+    try { return JSON.stringify(v, null, 2); }
+    catch (_) { return String(v); }
   }
 
   // ───────── Peers view ─────————

--- a/crates/ctxd-dashboard/assets/style.css
+++ b/crates/ctxd-dashboard/assets/style.css
@@ -266,6 +266,67 @@ main {
   padding: 1px 2px; border-radius: 2px;
 }
 
+/* —— Event detail ————————————————————————————————— */
+.event-back {
+  display: inline-block;
+  color: var(--ink-2);
+  font-size: var(--t-sm);
+  margin-bottom: var(--s-3);
+  padding: 4px 0;
+}
+.event-back:hover { color: var(--accent); }
+
+.event-content { padding: 0; }
+.event-text {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: var(--t-md);
+  line-height: 1.6;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 72ch;
+}
+.event-json {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.event-meta {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: var(--s-2) var(--s-4);
+  margin: 0;
+  font-size: var(--t-xs);
+}
+.event-meta dt {
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.event-meta dd {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+
+.event-raw summary {
+  cursor: pointer;
+  color: var(--ink-2);
+  font-size: var(--t-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: var(--s-2);
+}
+.event-raw summary:hover { color: var(--accent); }
+.event-raw[open] summary { color: var(--ink); }
+
 /* —— Peers ——————————————————————————————————————— */
 .peer-row, .approval-row {
   padding: var(--s-3) 0;


### PR DESCRIPTION
## Why

User feedback against the merged dashboard: "It is good but not able to view the actual memory content."

The recent-events panel and search results both wrap rows as `<a href="#/event/<id>">`, but the JS routes map never registered an `event` handler, so clicks silently fell back to the overview view. The whole point of the dashboard is "see what's in your substrate," and you couldn't see what was in any individual event. v1 omission, not a v2 deferral.

## What

`#/event/<id>` now renders a real detail view. Backed by the existing `GET /v1/events/{id}` endpoint (already shipped in #19), so this is purely a frontend change — no API or store work.

Four panels:

- **Content** — leads with `event.data.content` rendered in the serif body face for readable wrapping. Falls back to pretty-printed JSON for events that don't follow the `{content: "..."}` convention (e.g. ctx.fact rows that store structured data).
- **Metadata** — subject, type, time (raw RFC3339 + human-formatted local time), source, id. 130px label / 1fr value grid.
- **Provenance** — predecessor hash, parents, signature, attestation. Only rendered when at least one is set, so the typical un-signed local event doesn't show an empty section.
- **Raw** — full event JSON in a `<details>` collapsed by default, for the "show me the wire form" power users.

Plus a `← back` link at the top so back-button-shy users can return without trusting the browser back button.

404 from the API renders an inline "event not found" empty state (e.g. when following an old link from a different DB); other errors use the existing error panel.

## Plumbing

- New `event` route in the routes map.
- `parseRoute()` now returns `rest` (path segments after the route) so renderers can extract URL params without re-parsing `location.hash`. Existing renderers ignore the new arg.
- CSS additions: `.event-back`, `.event-content`, `.event-text` (serif), `.event-json` (mono mini-text), `.event-meta` (label/value grid), `.event-raw` (collapsible).

## Test plan

- [ ] cargo fmt + cargo clippy --all-targets --all-features -- -D warnings clean
- [ ] cargo test -p ctxd-dashboard (9 tests pass)
- [ ] CI green
- [ ] Click an event row on overview → detail view shows the content
- [ ] Click an event row on search results → same
- [ ] `← back` returns to the previous view
- [ ] Navigate to `#/event/00000000-0000-0000-0000-000000000000` → "event not found" empty state, not a console error

## Out of scope (still in TODOs.md)

- Modal/drawer-over-current-view variant of the detail (the original plan mentioned it; standalone page is honest about what we have)
- "Related events" / graph view (v2)
- Edit / re-sign actions (v3, blocked on remote-auth model)