### PR TITLE
feat(dashboard): subject detail view (click a subject name to read its events)

### DIFF
--- a/crates/ctxd-dashboard/assets/app.js
+++ b/crates/ctxd-dashboard/assets/app.js
@@ -90,6 +90,7 @@
     search: renderSearch,
     peers: renderPeers,
     event: renderEvent,
+    subject: renderSubjectDetail,
   };
 
   let currentRoute = null;
@@ -356,29 +357,129 @@
     for (const child of (node.children || [])) {
       const li = el('li');
       const expandable = (child.children || []).length > 0;
+
+      // Chevron toggles expand/collapse; the name is a real link to
+      // the subject's events. Two distinct click targets so the user
+      // can drill into either dimension without "click the name to
+      // expand, click the name *again* to view events" ambiguity.
+      const chev = el('span', {
+        class: 'chev' + (expandable ? ' chev--btn' : ''),
+        role: expandable ? 'button' : null,
+        'aria-label': expandable ? 'toggle children' : null,
+      }, expandable ? '▸' : ' ');
+
+      const nameLink = el('a', {
+        class: 'nm',
+        href: `#/subject/${encodeURIComponent(child.name)}`,
+        title: `view events under ${child.name}`,
+      }, child.name);
+
       const nodeLine = el('span', { class: 'tree-node', role: 'treeitem' },
-        el('span', { class: 'chev' }, expandable ? '▸' : ' '),
-        el('span', { class: 'nm' }, child.name),
+        chev,
+        nameLink,
         el('span', { class: 'ct' }, fmtCount(child.count)));
       li.append(nodeLine);
+
       if (expandable) {
         let expanded = depth < 1;
         const subUl = expanded ? buildTreeNode(child, depth + 1) : null;
         if (subUl) li.append(subUl);
-        nodeLine.addEventListener('click', () => {
+        chev.addEventListener('click', (ev) => {
+          ev.preventDefault();
+          ev.stopPropagation();
           expanded = !expanded;
-          nodeLine.querySelector('.chev').textContent = expanded ? '▾' : '▸';
+          chev.textContent = expanded ? '▾' : '▸';
           if (expanded) {
             li.append(buildTreeNode(child, depth + 1));
           } else {
             li.querySelector('ul')?.remove();
           }
         });
-        if (subUl) nodeLine.querySelector('.chev').textContent = '▾';
+        if (subUl) chev.textContent = '▾';
       }
       ul.append(li);
     }
     return ul;
+  }
+
+  // ───────── Subject detail view ─────────
+  //
+  // Renders events under a given subject (recursive). Hash route:
+  // #/subject/<url-encoded-path>. Reached by clicking a subject name
+  // in the tree, or by typing the URL.
+  //
+  // The subject path is URL-encoded as a single segment so paths like
+  // `/work/local/files/a.md` survive routing without the slashes
+  // confusing parseRoute.
+
+  async function renderSubjectDetail(main, _params, rest) {
+    main.innerHTML = '';
+    const subject = rest.length ? decodeURIComponent(rest[0]) : null;
+    if (!subject) {
+      main.append(errorPanel('no subject', new Error('expected #/subject/<path>')));
+      return;
+    }
+
+    const back = el('a', { class: 'event-back', href: '#/subjects' }, '← all subjects');
+    main.append(back);
+
+    // Header panel: subject path + count.
+    const head = el('div', { class: 'panel-head' },
+      el('h2', {}, subject));
+    const headPanel = el('section', { class: 'panel' }, head);
+    const eventsHost = el('div', { class: 'events', id: 'subject-events' },
+      ...shimmerRows(8));
+    headPanel.append(eventsHost);
+    main.append(headPanel);
+
+    // Pull events under this subject (recursive). The endpoint's
+    // subject filter implies recursive descent.
+    let page;
+    try {
+      page = await api(`/v1/events?subject=${encodeURIComponent(subject)}&limit=200`);
+    } catch (e) {
+      eventsHost.replaceWith(errorPanel('couldn\'t load events', e));
+      return;
+    }
+
+    // Update the head with the count once we know it.
+    head.append(el('span', { class: 'panel-meta' }, `${page.events.length} event${page.events.length === 1 ? '' : 's'}`));
+
+    eventsHost.innerHTML = '';
+    if (!page.events.length) {
+      eventsHost.append(emptyMsg(
+        `no events under ${subject}`,
+        'this subject is empty or has only descendants. try the parent prefix to see them.'));
+      return;
+    }
+    for (const e of page.events) eventsHost.append(eventRow(e, false));
+
+    // If there's a next page, surface a "load more" button.
+    if (page.next_cursor) {
+      const more = el('button', { class: 'btn btn--ghost btn--sm', type: 'button' },
+        `load older (cursor: ${page.next_cursor.slice(0, 8)}…)`);
+      let cursor = page.next_cursor;
+      more.addEventListener('click', async () => {
+        more.disabled = true;
+        more.textContent = 'loading…';
+        try {
+          const next = await api(
+            `/v1/events?subject=${encodeURIComponent(subject)}&before=${encodeURIComponent(cursor)}&limit=200`);
+          for (const e of next.events) eventsHost.append(eventRow(e, false));
+          if (next.next_cursor) {
+            cursor = next.next_cursor;
+            more.disabled = false;
+            more.textContent = `load older (cursor: ${cursor.slice(0, 8)}…)`;
+          } else {
+            more.remove();
+          }
+        } catch (e) {
+          more.textContent = 'failed — click to retry';
+          more.disabled = false;
+        }
+      });
+      headPanel.append(more);
+    }
   }
 
   // ───────── Search view ─────────

--- a/crates/ctxd-dashboard/assets/app.js
+++ b/crates/ctxd-dashboard/assets/app.js
@@ -454,10 +454,12 @@
     }
     for (const e of page.events) eventsHost.append(eventRow(e, false));
 
-    // If there's a next page, surface a "load more" button.
+    // If there's a next page, surface a "load older" button. The
+    // cursor is an API implementation detail (opaque base64 of seq);
+    // we don't show it in the UI.
     if (page.next_cursor) {
       const more = el('button', { class: 'btn btn--ghost btn--sm', type: 'button' },
-        `load older (cursor: ${page.next_cursor.slice(0, 8)}…)`);
+        'load older');
       let cursor = page.next_cursor;
       more.addEventListener('click', async () => {
         more.disabled = true;
@@ -469,7 +471,7 @@
           if (next.next_cursor) {
             cursor = next.next_cursor;
             more.disabled = false;
-            more.textContent = `load older (cursor: ${cursor.slice(0, 8)}…)`;
+            more.textContent = 'load older';
           } else {
             more.remove();
           }

--- a/crates/ctxd-dashboard/assets/app.js
+++ b/crates/ctxd-dashboard/assets/app.js
@@ -89,6 +89,7 @@
     subjects: renderSubjects,
     search: renderSearch,
     peers: renderPeers,
+    event: renderEvent,
   };
 
   let currentRoute = null;
@@ -97,13 +98,15 @@
   function parseRoute() {
     const hash = location.hash.replace(/^#\/?/, '') || '';
     const [path, query] = hash.split('?');
-    const route = path.split('/')[0] || 'overview';
+    const segments = path.split('/').filter(Boolean);
+    const route = segments[0] || 'overview';
+    const rest = segments.slice(1);
     const params = new URLSearchParams(query || '');
-    return { route, params };
+    return { route, rest, params };
   }
 
   function navigate() {
-    const { route, params } = parseRoute();
+    const { route, rest, params } = parseRoute();
     if (currentCleanup) {
       currentCleanup();
       currentCleanup = null;
@@ -116,7 +119,7 @@
     });
     const main = $('#main');
     main.innerHTML = '<p class="loading">loading…</p>';
-    Promise.resolve(renderer(main, params)).catch((err) => {
+    Promise.resolve(renderer(main, params, rest)).catch((err) => {
       main.innerHTML = '';
       main.append(errorPanel(`failed to render ${route}`, err));
     });
@@ -442,6 +445,90 @@
         el('span', { class: 'ty' }, hit.type || ''),
         el('span', { class: 'sub' }, hit.subject)),
       el('div', { class: 'snippet', html: renderSnippet(hit.snippet) }));
+  }
+
+  // ───────── Event detail view ─────────
+  //
+  // Renders /v1/events/<id>. Lead with the actual content (the
+  // memory you wrote), then metadata + signature/parents/attestation
+  // for the technically curious. Hash route: #/event/<id>.
+
+  async function renderEvent(main, _params, rest) {
+    main.innerHTML = '';
+    const id = rest[0];
+    if (!id) {
+      main.append(errorPanel('no event id', new Error('expected #/event/<id>')));
+      return;
+    }
+
+    const back = el('a', { class: 'event-back', href: 'javascript:history.back()' },
+      '← back');
+    main.append(back);
+
+    let event;
+    try {
+      event = await api(`/v1/events/${encodeURIComponent(id)}`);
+    } catch (e) {
+      if (e.status === 404) {
+        main.append(emptyMsg('event not found',
+          `no event with id ${id}. it may have been from a different database, or the id may be malformed.`));
+      } else {
+        main.append(errorPanel('couldn\'t load event', e));
+      }
+      return;
+    }
+
+    // Headline: the content. data.content for ctx.note / ctx.fact /
+    // etc.; falls back to pretty-printed JSON for events that don't
+    // follow that convention.
+    const contentHost = el('div', { class: 'event-content' });
+    const content = event.data && typeof event.data === 'object'
+      ? event.data.content
+      : null;
+    if (typeof content === 'string' && content.length > 0) {
+      contentHost.append(el('pre', { class: 'event-text' }, content));
+    } else {
+      // No `content` field — show the whole `data` blob.
+      contentHost.append(el('pre', { class: 'event-json' }, prettyJson(event.data)));
+    }
+    main.append(panel('Content', contentHost));
+
+    // Metadata table (subject, type, time, source).
+    const meta = el('dl', { class: 'event-meta' });
+    addMetaRow(meta, 'subject', event.subject);
+    addMetaRow(meta, 'type', event.type || event.event_type);
+    addMetaRow(meta, 'time', `${event.time} (${fmtTime(event.time)})`);
+    if (event.source) addMetaRow(meta, 'source', event.source);
+    addMetaRow(meta, 'id', event.id);
+    main.append(panel('Metadata', meta));
+
+    // Provenance: predecessor hash, parents, signature, attestation.
+    // Most events have these blank or null; only render the section
+    // if at least one is set so we don't waste vertical space.
+    const provHost = el('dl', { class: 'event-meta' });
+    let hasProv = false;
+    if (event.predecessorhash) { addMetaRow(provHost, 'predecessor', event.predecessorhash); hasProv = true; }
+    if (event.parents && event.parents.length) { addMetaRow(provHost, 'parents', event.parents.join(', ')); hasProv = true; }
+    if (event.signature) { addMetaRow(provHost, 'signature', event.signature); hasProv = true; }
+    if (event.attestation) { addMetaRow(provHost, 'attestation', `${event.attestation.length} bytes`); hasProv = true; }
+    if (hasProv) main.append(panel('Provenance', provHost));
+
+    // Raw JSON, collapsed by default — for the "I trust nothing,
+    // show me the wire form" power user.
+    const detail = el('details', { class: 'event-raw' },
+      el('summary', {}, 'raw event JSON'),
+      el('pre', { class: 'event-json' }, prettyJson(event)));
+    main.append(panel('Raw', detail));
+  }
+
+  function addMetaRow(dl, label, value) {
+    dl.append(el('dt', {}, label));
+    dl.append(el('dd', {}, String(value == null ? '' : value)));
+  }
+
+  function prettyJson(v) {
+    try { return JSON.stringify(v, null, 2); }
+    catch (_) { return String(v); }
   }
 
   // ───────── Peers view ─────————

--- a/crates/ctxd-dashboard/assets/style.css
+++ b/crates/ctxd-dashboard/assets/style.css
@@ -158,6 +158,13 @@ main {
   letter-spacing: 0.08em;
   color: var(--ink-2);
 }
+.panel-head .panel-meta {
+  margin-left: var(--s-3);
+  font-size: var(--t-xs);
+  color: var(--ink-3);
+  text-transform: none;
+  letter-spacing: 0;
+}
 
 /* —— Stats strip ——————————————————————————————— */
 .stats {
@@ -235,7 +242,10 @@ main {
 }
 .tree-node:hover { background: var(--paper-3); }
 .tree-node .chev { color: var(--ink-3); width: 12px; display: inline-block; }
+.tree-node .chev--btn { cursor: pointer; }
+.tree-node .chev--btn:hover { color: var(--accent); }
 .tree-node .nm { color: var(--ink); }
+.tree-node a.nm:hover { color: var(--accent); }
 .tree-node .ct { color: var(--ink-3); font-variant-numeric: tabular-nums; margin-left: var(--s-2); }
 
 /* —— Search —————————————————————————————————————— */

--- a/crates/ctxd-dashboard/assets/style.css
+++ b/crates/ctxd-dashboard/assets/style.css
@@ -266,6 +266,67 @@ main {
   padding: 1px 2px; border-radius: 2px;
 }
 
+/* —— Event detail ————————————————————————————————— */
+.event-back {
+  display: inline-block;
+  color: var(--ink-2);
+  font-size: var(--t-sm);
+  margin-bottom: var(--s-3);
+  padding: 4px 0;
+}
+.event-back:hover { color: var(--accent); }
+
+.event-content { padding: 0; }
+.event-text {
+  margin: 0;
+  font-family: var(--font-serif);
+  font-size: var(--t-md);
+  line-height: 1.6;
+  color: var(--ink);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-width: 72ch;
+}
+.event-json {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--ink-2);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.event-meta {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: var(--s-2) var(--s-4);
+  margin: 0;
+  font-size: var(--t-xs);
+}
+.event-meta dt {
+  color: var(--ink-3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.event-meta dd {
+  margin: 0;
+  color: var(--ink);
+  font-family: var(--font-mono);
+  word-break: break-all;
+}
+
+.event-raw summary {
+  cursor: pointer;
+  color: var(--ink-2);
+  font-size: var(--t-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: var(--s-2);
+}
+.event-raw summary:hover { color: var(--accent); }
+.event-raw[open] summary { color: var(--ink); }
+
 /* —— Peers ——————————————————————————————————————— */
 .peer-row, .approval-row {
   padding: var(--s-3) 0;


### PR DESCRIPTION
## Why

Same class of v1 omission as #20. User feedback: *"in subjects view I only see count against each subject. Should I see the listing as well?"*

The plan called for "left rail with the tree, right pane with events under the selected node (split 30/70)" — only the tree and count badge shipped. You could see that `/me/facts` had 10 events under it, but not what those 10 events actually said.

## What

`#/subject/<url-encoded-path>` now renders a real subject-detail view. Backed by the existing `GET /v1/events?subject=<path>` endpoint (already shipped in #19, filters recursively), so this is purely a frontend change.

- **Click a subject name in the tree** → land on the subject's events. Newest first, dense rows, ~110ms to first paint locally.
- **Click the chevron** → toggle expand/collapse like before. The two click targets are now distinct, so there's no "click name to expand, click name *again* to view" confusion.
- **Load older** → if the first 200 events don't fit, a button at the bottom pages via the opaque `next_cursor` already shipped in `/v1/events`.
- **← all subjects** → back link to the tree.
- Each event row in the listing is the same `eventRow` from the rest of the dashboard, so clicking an individual event drills into the detail view from #20.

## Plumbing

- New `subject` route in the routes map.
- Tree click handlers split: chevron is a `<span role="button">` that toggles, name is a real `<a href="#/subject/...">` link.
- `<a>`-styled `nm` keeps the same look but gets keyboard focus and right-click "open in new tab" for free.
- Subject path is URL-encoded as a single segment so paths like `/work/local/files/a.md` survive routing.

## Stacking note

This branches from `feat/dashboard-event-detail` (#20) because both share the `parseRoute()` change that returns `rest` for path segments. Will rebase cleanly once #20 merges first; if this merges first, #20 rebases just as cleanly. No conflict either way.

## Test plan

- [ ] cargo fmt + clippy --all-targets --all-features -- -D warnings clean
- [ ] cargo test -p ctxd-dashboard (9 tests pass)
- [ ] CI green
- [ ] Click `/me/facts` in the tree → land on a list of events under `/me/facts` (and any descendants)
- [ ] Click an event row in that list → drills into event detail (per #20)
- [ ] Click chevron next to `/me` → toggles expand/collapse without navigating away
- [ ] `← all subjects` returns to the tree
- [ ] Subject with thousands of events → "load older" button works, cursor pages forward

## Out of scope (still in TODOS.md)

- Subjects-as-graph view (entities + relationships) — v2
- Time-travel slider on the subject detail (`?as_of=...`) — v2
- Split 30/70 left-rail-and-right-pane layout — current: full-width single-pane is honest about a single binding, easier to read on narrow viewports