### PR TITLE
release: v0.4.1 — path footgun + best-effort hooks + proxy notification fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The global `--db` flag defaulted to the literal string `"ctxd.db"` — relative 
 - **`--db` now defaults to `paths::default_db_path()`.** macOS resolves to `~/Library/Application Support/ctxd/ctxd.db`, Linux to `$XDG_DATA_HOME/ctxd/ctxd.db`, Windows to `%APPDATA%\ctxd\data\ctxd.db`. `CTXD_DATA_DIR` overrides. Existing `--db <path>` invocations are unchanged.
 - **`service-start` probes both pidfile paths.** When the cli.db pidfile doesn't show up within the deadline, also try the canonical default-db pidfile. Defense-in-depth: a 0.4 binary running against an old plist (or vice-versa) won't wedge.
 - **`Outcome.clients_configured` and `Outcome.adapters_enabled` populate correctly.** The closing `done — N client(s) configured, M adapter(s) enabled` line was always `0 / 0` because the pipeline never threaded the slugs through. Now it reads `done — 3 client(s) configured` (claude-desktop, claude-code, codex) on a typical onboard.
+- **`ctxd hook` now exits 0 silently when the DB can't be opened.** Stale hooks left behind by a sandboxed onboard run (e.g. `CTXD_DATA_DIR=$(mktemp -d) ctxd onboard`, then tempdir wiped) used to surface SQLITE_CANTOPEN as a non-zero exit. Claude Code rendered that as `Stop hook error: ... (code: 14) unable to open database file` in the chat on every Stop event — a permanent visible failure mode that could only be cleared by re-running onboard. Hooks are now best-effort end-to-end: any failure (missing DB, locked DB, malformed slug, malformed payload) logs to stderr and exits 0. Five integration tests pin the contract.
+- **MCP stdio proxy no longer emits empty frames for JSON-RPC notifications.** The proxy used to write a bare newline whenever the daemon answered `202 Accepted` to a notification (no `id`, no response expected). Line-oriented MCP clients then tried to `JSON.parse("")` and surfaced "Unexpected end of JSON input" — visible in the Claude Desktop log around the `notifications/initialized` handshake.
 
 ### Migration from v0.4.0
 
@@ -31,6 +33,8 @@ rm -rf "$HOME/Library/Application Support/ctxd/caps"
 rm -f  "$HOME/Library/Application Support/ctxd/ctxd.db.pid"
 ctxd onboard   # picks up the v0.4.1 default
 ```
+
+If you saw `Stop hook error: ... (code: 14) unable to open database file` repeating in Claude Code chats, upgrading to v0.4.1 silences the symptom immediately (hooks are now best-effort). To also clear out the stale entry that's been firing, run `ctxd onboard --only configure-clients` once on v0.4.1 — settings.json is rewritten with the canonical DB path.
 
 ## v0.4 — 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v0.4.1 — 2026-05-03
+
+Fixes the path footgun shipped in v0.4: **`ctxd onboard` now works regardless of which directory you invoke it from.**
+
+### What was wrong
+
+The global `--db` flag defaulted to the literal string `"ctxd.db"` — relative to cwd. When `ctxd onboard` ran from any directory other than `~/Library/Application Support/ctxd/`:
+
+* The foreground command opened the SQLite DB at `<cwd>/ctxd.db`, generated a root_key there, and minted six capability files at the global `<config_dir>/ctxd/caps/<client>.bk` path against that root_key.
+* The launchd plist that `service-install` wrote pointed the daemon at the canonical `~/Library/Application Support/ctxd/ctxd.db` (because the plist's WorkingDirectory is `paths::data_dir()`). The daemon there generated its OWN root_key.
+* `service-start` polled the cli.db's pidfile (`<cwd>/ctxd.db.pid`) but the launchd-spawned daemon wrote its pidfile alongside the canonical DB — the two paths never aligned, so onboard always failed at the 10-second `/health` deadline.
+* Even after manual cleanup, every `ctxd doctor` reported `caps-valid: failed` for all six clients with `biscuit error: error deserializing or verifying the token` — the caps were signed by the cwd DB's root_key but verified against the canonical DB's root_key.
+
+### Fixes
+
+- **`--db` now defaults to `paths::default_db_path()`.** macOS resolves to `~/Library/Application Support/ctxd/ctxd.db`, Linux to `$XDG_DATA_HOME/ctxd/ctxd.db`, Windows to `%APPDATA%\ctxd\data\ctxd.db`. `CTXD_DATA_DIR` overrides. Existing `--db <path>` invocations are unchanged.
+- **`service-start` probes both pidfile paths.** When the cli.db pidfile doesn't show up within the deadline, also try the canonical default-db pidfile. Defense-in-depth: a 0.4 binary running against an old plist (or vice-versa) won't wedge.
+- **`Outcome.clients_configured` and `Outcome.adapters_enabled` populate correctly.** The closing `done — N client(s) configured, M adapter(s) enabled` line was always `0 / 0` because the pipeline never threaded the slugs through. Now it reads `done — 3 client(s) configured` (claude-desktop, claude-code, codex) on a typical onboard.
+
+### Migration from v0.4.0
+
+If you ran `ctxd onboard` on v0.4.0 from outside `Application Support` and hit the symptoms above, run the cleanup once on your machine:
+
+```bash
+launchctl bootout gui/$UID/com.ctxd.serve 2>/dev/null
+launchctl bootout gui/$UID/dev.ctxd.daemon 2>/dev/null
+rm -f ~/Library/LaunchAgents/{com.ctxd.serve,dev.ctxd.daemon}.plist
+rm -rf "$HOME/Library/Application Support/ctxd/caps"
+rm -f  "$HOME/Library/Application Support/ctxd/ctxd.db.pid"
+ctxd onboard   # picks up the v0.4.1 default
+```
+
 ## v0.4 — 2026-05-02
 
 The plug-and-play release. **Every AI on your machine, one memory** — installed in two commands.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1010,7 +1010,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-adapter-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "clap",
@@ -1024,7 +1024,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-adapter-fs"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1046,7 +1046,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-adapter-github"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1072,7 +1072,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-adapter-gmail"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1102,7 +1102,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-cap"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1120,7 +1120,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1167,7 +1167,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-client"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "chrono",
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -1205,7 +1205,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-dashboard"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum 0.8.9",
  "ctxd-cap",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-embed"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "reqwest",
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-http"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "axum 0.8.9",
  "base64 0.22.1",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-mcp"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "axum 0.8.9",
@@ -1295,7 +1295,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-store"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ctxd-store-core",
  "ctxd-store-sqlite",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-store-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1318,7 +1318,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-store-duckobj"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -1342,7 +1342,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-store-postgres"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1363,7 +1363,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-store-sqlite"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "ctxd-wire"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "ctxd-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/keeprlabs/ctxd"

--- a/clients/rust/ctxd-client/Cargo.toml
+++ b/clients/rust/ctxd-client/Cargo.toml
@@ -26,8 +26,8 @@ path = "src/lib.rs"
 # wire format moves in lockstep with the daemon — an SDK published
 # against a different ctxd-core minor version would silently produce
 # wrong canonical bytes.
-ctxd-core = { path = "../../../crates/ctxd-core", version = "0.4.0" }
-ctxd-wire = { path = "../../../crates/ctxd-wire", version = "0.4.0" }
+ctxd-core = { path = "../../../crates/ctxd-core", version = "0.4.1" }
+ctxd-wire = { path = "../../../crates/ctxd-wire", version = "0.4.1" }
 
 # Serialization. Both used by the HTTP admin types and (transitively)
 # by the wire protocol surface.

--- a/crates/ctxd-cli/src/main.rs
+++ b/crates/ctxd-cli/src/main.rs
@@ -13,7 +13,7 @@ use ctxd_store::caveat_state::SqliteCaveatState;
 use ctxd_store::EventStore;
 use opentelemetry::trace::TracerProvider;
 use protocol::ProtocolClient;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -57,6 +57,67 @@ fn resolve_db_path(cli_db: &Option<PathBuf>) -> Result<PathBuf> {
     }
     ctxd_cli::onboard::paths::default_db_path()
         .context("could not resolve default DB path; pass --db explicitly or set CTXD_DATA_DIR")
+}
+
+/// Run a Claude Code hook in pure best-effort mode.
+///
+/// Reads up to 64 KiB of JSON payload from stdin and appends one event
+/// to `/me/sessions/<slug>`. Any error — DB path resolves to a wiped
+/// tempdir, DB exclusively locked, parent dir missing, permission
+/// denied, malformed slug — is logged to stderr and we exit 0.
+///
+/// Why not propagate errors: Claude Code surfaces a non-zero hook exit
+/// to the user as a "Stop hook error" message in the chat, on every
+/// session end. A stale settings.json entry pointing at a deleted
+/// tempdir would spam the user forever; a brief lock-contention with
+/// the daemon would interrupt the conversation. Hooks are
+/// instrumentation, not a critical path — the user must never know
+/// they exist when they fail.
+async fn run_hook(slug: &str, _cap_file: Option<&Path>, db_path: &Path) {
+    use std::io::Read as _;
+    let mut payload = Vec::with_capacity(4096);
+    let _ = std::io::stdin()
+        .lock()
+        .take(65_536)
+        .read_to_end(&mut payload);
+    let parsed: serde_json::Value = if payload.is_empty() {
+        serde_json::json!({})
+    } else {
+        serde_json::from_slice(&payload).unwrap_or_else(|_| {
+            serde_json::json!({
+                "raw": String::from_utf8_lossy(&payload).into_owned(),
+            })
+        })
+    };
+    let subject_path = format!("/me/sessions/{slug}");
+    let subject = match Subject::new(&subject_path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ctxd hook: invalid slug {slug:?}: {e}");
+            return;
+        }
+    };
+    let data = serde_json::json!({
+        "event": slug,
+        "captured_at": chrono::Utc::now().to_rfc3339(),
+        "payload": parsed,
+    });
+    let event = Event::new(
+        "ctxd://hook".to_string(),
+        subject,
+        format!("hook.{slug}"),
+        data,
+    );
+    let store = match EventStore::open(db_path).await {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("ctxd hook: open failed (best-effort): {e}");
+            return;
+        }
+    };
+    if let Err(e) = store.append(event).await {
+        eprintln!("ctxd hook: append failed (best-effort): {e}");
+    }
 }
 
 #[derive(Subcommand)]
@@ -586,6 +647,22 @@ async fn main() -> Result<()> {
     let _otel_guard = init_tracing();
 
     let cli = Cli::parse();
+
+    // Short-circuit Claude Code hooks before the upfront EventStore::open
+    // below. The hook command must be best-effort: a stale --db path in
+    // settings.json (e.g. a tempdir from a sandboxed onboard run that's
+    // since been wiped) would otherwise propagate SQLITE_CANTOPEN as a
+    // non-zero exit, and Claude Code surfaces that to the user as a
+    // "Stop hook error" on every session end — a permanent, visible
+    // failure mode the user can only break out of by re-running onboard.
+    if let Commands::Hook { slug, cap_file } = &cli.command {
+        match resolve_db_path(&cli.db) {
+            Ok(db_path) => run_hook(slug, cap_file.as_deref(), &db_path).await,
+            Err(e) => eprintln!("ctxd hook: cannot resolve DB path (best-effort): {e}"),
+        }
+        return Ok(());
+    }
+
     let db_path = resolve_db_path(&cli.db)?;
     let store = EventStore::open(&db_path)
         .await
@@ -1360,50 +1437,12 @@ async fn main() -> Result<()> {
             }
         }
 
-        Commands::Hook { slug, cap_file } => {
-            let _ = cap_file; // accepted; future: verify before append
-                              // Read up to 64 KiB from stdin. Hooks send small JSON
-                              // payloads; we cap to keep this pure overhead-free.
-            use std::io::Read as _;
-            let mut payload = Vec::with_capacity(4096);
-            let _ = std::io::stdin()
-                .lock()
-                .take(65_536)
-                .read_to_end(&mut payload);
-            let parsed: serde_json::Value = if payload.is_empty() {
-                serde_json::json!({})
-            } else {
-                serde_json::from_slice(&payload).unwrap_or_else(|_| {
-                    serde_json::json!({
-                        "raw": String::from_utf8_lossy(&payload).into_owned(),
-                    })
-                })
-            };
-            let subject_path = format!("/me/sessions/{slug}");
-            let subject = match Subject::new(&subject_path) {
-                Ok(s) => s,
-                Err(e) => {
-                    eprintln!("ctxd hook: invalid slug {slug:?}: {e}");
-                    return Ok(());
-                }
-            };
-            let data = serde_json::json!({
-                "event": slug,
-                "captured_at": chrono::Utc::now().to_rfc3339(),
-                "payload": parsed,
-            });
-            let event = Event::new(
-                "ctxd://hook".to_string(),
-                subject,
-                format!("hook.{slug}"),
-                data,
-            );
-            // Best-effort append; never panic from a hook.
-            if let Err(e) = store.append(event).await {
-                eprintln!("ctxd hook: append failed (best-effort): {e}");
-            }
-            // Exit 0 regardless — hooks must not surface errors to
-            // Claude Code or it spams the user on every Stop.
+        Commands::Hook { .. } => {
+            // Handled by the early short-circuit in main(). Reaching
+            // this arm would mean we opened the store unnecessarily;
+            // unreachable in practice but kept exhaustive so adding a
+            // new variant fails to compile until a handler exists.
+            unreachable!("Hook handled before match");
         }
 
         Commands::Doctor { json } => {

--- a/crates/ctxd-cli/src/main.rs
+++ b/crates/ctxd-cli/src/main.rs
@@ -24,11 +24,39 @@ use tracing_subscriber::EnvFilter;
 #[command(name = "ctxd", version, about)]
 struct Cli {
     /// Path to the SQLite database file.
-    #[arg(long, default_value = "ctxd.db", global = true)]
-    db: PathBuf,
+    ///
+    /// Defaults to the canonical platform path (resolved at runtime
+    /// via `onboard::paths::default_db_path()`):
+    ///
+    /// * macOS  → `~/Library/Application Support/ctxd/ctxd.db`
+    /// * Linux  → `$XDG_DATA_HOME/ctxd/ctxd.db`
+    /// * Windows → `%APPDATA%\ctxd\data\ctxd.db`
+    ///
+    /// Override with `CTXD_DATA_DIR` (also affects related files
+    /// like the pidfile and HNSW sidecars).
+    ///
+    /// Pre-v0.4.1 ctxd defaulted this to `"ctxd.db"` (relative to
+    /// cwd), which split the cli.db and the launchd plist's `--db`
+    /// across different absolute paths whenever onboard was invoked
+    /// from outside `Application Support` — caps minted against the
+    /// cli.db's root_key never matched the daemon's. See #27.
+    #[arg(long, global = true)]
+    db: Option<PathBuf>,
 
     #[command(subcommand)]
     command: Commands,
+}
+
+/// Resolve the effective DB path: the user's `--db` override if set,
+/// otherwise `paths::default_db_path()`. Bails with a friendly error
+/// if neither is available (e.g. `$HOME` unset on a misconfigured
+/// system).
+fn resolve_db_path(cli_db: &Option<PathBuf>) -> Result<PathBuf> {
+    if let Some(p) = cli_db {
+        return Ok(p.clone());
+    }
+    ctxd_cli::onboard::paths::default_db_path()
+        .context("could not resolve default DB path; pass --db explicitly or set CTXD_DATA_DIR")
 }
 
 #[derive(Subcommand)]
@@ -558,7 +586,8 @@ async fn main() -> Result<()> {
     let _otel_guard = init_tracing();
 
     let cli = Cli::parse();
-    let store = EventStore::open(&cli.db)
+    let db_path = resolve_db_path(&cli.db)?;
+    let store = EventStore::open(&db_path)
         .await
         .context("failed to open event store")?;
     // Load or create the root capability key, persisted in the database
@@ -633,7 +662,7 @@ async fn main() -> Result<()> {
                 storage,
                 storage_uri,
                 federation: true,
-                db_path: Some(cli.db.clone()),
+                db_path: Some(db_path.clone()),
                 cap_files: cap_file,
             };
             ctxd_cli::serve::serve(cfg, store, cap_engine, caveat_state, pending_approval_tx)
@@ -659,7 +688,7 @@ async fn main() -> Result<()> {
                 storage: "sqlite".to_string(),
                 storage_uri: None,
                 federation: false,
-                db_path: Some(cli.db.clone()),
+                db_path: Some(db_path.clone()),
                 cap_files: vec![],
             };
             // Spawn a deferred opener that fires once the bind has
@@ -1155,7 +1184,7 @@ async fn main() -> Result<()> {
                 github: AdapterChoice::Skip,
                 fs,
                 only: only_set,
-                db_path: cli.db.clone(),
+                db_path: db_path.clone(),
                 bind,
                 wire_bind,
             };
@@ -1191,7 +1220,7 @@ async fn main() -> Result<()> {
                 github: AdapterChoice::Skip,
                 fs: vec![],
                 only: None,
-                db_path: cli.db.clone(),
+                db_path: db_path.clone(),
                 bind: "127.0.0.1:7777".to_string(),
                 wire_bind: "127.0.0.1:7778".to_string(),
             };
@@ -1209,10 +1238,10 @@ async fn main() -> Result<()> {
             let admin_url = match url {
                 Some(u) => u,
                 None => {
-                    let pf = ctxd_cli::pidfile::read(&cli.db).ok_or_else(|| {
+                    let pf = ctxd_cli::pidfile::read(&db_path).ok_or_else(|| {
                         anyhow::anyhow!(
                             "no pidfile at {} — daemon not running, or pass --url",
-                            ctxd_cli::pidfile::pidfile_path(&cli.db).to_string_lossy()
+                            ctxd_cli::pidfile::pidfile_path(&db_path).to_string_lossy()
                         )
                     })?;
                     format!("http://{}", pf.admin_bind)
@@ -1378,7 +1407,7 @@ async fn main() -> Result<()> {
         }
 
         Commands::Doctor { json } => {
-            let checks = ctxd_cli::onboard::doctor::run(&cli.db).await;
+            let checks = ctxd_cli::onboard::doctor::run(&db_path).await;
             if json {
                 let summary = ctxd_cli::onboard::doctor::Summary::from_checks(&checks);
                 let body = serde_json::json!({

--- a/crates/ctxd-cli/src/mcp_proxy.rs
+++ b/crates/ctxd-cli/src/mcp_proxy.rs
@@ -136,10 +136,16 @@ pub async fn run(daemon_admin: &str, cap_b64: &str) -> Result<()> {
                 }
             }
             stdout.flush().await?;
-        } else {
-            // Plain JSON response — write as one line.
-            // Some servers pretty-print; collapse to single line so
-            // the MCP client's line-oriented reader sees one frame.
+        } else if !body.trim().is_empty() {
+            // Plain JSON response — write as one line. An empty body
+            // means the daemon answered 202 Accepted for a JSON-RPC
+            // notification (no `id`, no response expected); emitting
+            // even a bare newline would make line-oriented MCP
+            // clients try to JSON.parse("") and surface "Unexpected
+            // end of JSON input" — see Claude Desktop log around the
+            // notifications/initialized handshake. Some servers
+            // pretty-print; collapse to single line so the client's
+            // line reader sees one frame.
             let single_line = body.replace('\n', "");
             stdout.write_all(single_line.as_bytes()).await?;
             stdout.write_all(b"\n").await?;

--- a/crates/ctxd-cli/src/onboard/pipeline.rs
+++ b/crates/ctxd-cli/src/onboard/pipeline.rs
@@ -113,16 +113,16 @@ pub async fn onboard(cfg: PipelineConfig) -> Result<Outcome> {
     step_snapshot(&cfg, &emitter).await?;
     step_service_install(&cfg, &emitter)?;
     step_service_start(&cfg, &emitter).await?;
-    step_configure_clients(&cfg, &emitter)?;
+    let clients_configured = step_configure_clients(&cfg, &emitter)?;
     step_mint_capabilities(&cfg, &emitter).await?;
     step_seed_subjects(&cfg, &emitter).await?;
-    step_configure_adapters(&cfg, &emitter)?;
+    let adapters_enabled = step_configure_adapters(&cfg, &emitter)?;
     let doctor_summary = step_doctor(&cfg, &emitter).await?;
 
     let outcome = Outcome {
         onboarded: doctor_summary.failed == 0,
-        clients_configured: vec![], // populated in phase 2B
-        adapters_enabled: vec![],   // populated in phase 3B
+        clients_configured,
+        adapters_enabled,
         doctor: doctor_summary,
     };
     emitter.done(outcome.clone());
@@ -352,13 +352,29 @@ async fn step_service_start(cfg: &PipelineConfig, emitter: &Emitter) -> Result<(
     backend.start()?;
 
     // Wait for /health up to 10s. The pidfile is written by the
-    // daemon (phase 1A) once the listener is up; we poll until it
-    // appears or the timeout elapses.
+    // daemon (phase 1A) once the listener is up. Probe BOTH the
+    // cli.db pidfile and the canonical default-db pidfile — the
+    // launchd plist's --db is whatever was passed to onboard, but
+    // its WorkingDirectory is paths::data_dir(); a relative cli.db
+    // would put the plist's pidfile at <data_dir>/<basename>.pid
+    // while onboard's pidfile probe looks at <cwd>/<basename>.pid.
+    // Pre-0.4.1 the default --db was relative ("ctxd.db"), so the
+    // two paths diverged whenever onboard ran outside data_dir;
+    // probing both makes service-start tolerant of older daemons
+    // and any future path mismatch.
+    let canonical = paths::default_db_path().ok();
     let deadline = std::time::Instant::now() + Duration::from_secs(10);
     let started_at = std::time::Instant::now();
     let (admin_url, version) = loop {
         if let pidfile::DaemonState::Running(pf) = pidfile::detect(&cfg.db_path).await {
             break (format!("http://{}", pf.admin_bind), pf.version);
+        }
+        if let Some(c) = &canonical {
+            if c != &cfg.db_path {
+                if let pidfile::DaemonState::Running(pf) = pidfile::detect(c).await {
+                    break (format!("http://{}", pf.admin_bind), pf.version);
+                }
+            }
         }
         if std::time::Instant::now() >= deadline {
             emitter.error(
@@ -385,14 +401,21 @@ async fn step_service_start(cfg: &PipelineConfig, emitter: &Emitter) -> Result<(
     Ok(())
 }
 
-fn step_configure_clients(cfg: &PipelineConfig, emitter: &Emitter) -> Result<()> {
+/// Run the configure-clients step. Returns the slugs of clients
+/// whose config was successfully written (i.e. ApplyAction is one
+/// of Created / EntryAdded / EntryUpdated / Unchanged) — these
+/// flow through to `Outcome.clients_configured` so the closing
+/// `done` line accurately reports what happened. Codex with
+/// ManualPending is INCLUDED because the snippet file was written;
+/// the user needs to paste it but the step did its work.
+fn step_configure_clients(cfg: &PipelineConfig, emitter: &Emitter) -> Result<Vec<String>> {
     if !cfg.includes(StepName::ConfigureClients) {
-        return Ok(());
+        return Ok(Vec::new());
     }
     emitter.step_started(StepName::ConfigureClients);
     if cfg.dry_run {
         emitter.step_skipped(StepName::ConfigureClients, "dry-run");
-        return Ok(());
+        return Ok(Vec::new());
     }
     let binary = std::env::current_exe()
         .map_err(|e| anyhow::anyhow!("could not resolve current ctxd binary: {e}"))?;
@@ -404,6 +427,7 @@ fn step_configure_clients(cfg: &PipelineConfig, emitter: &Emitter) -> Result<()>
     let results = clients::apply_all(&spec);
     let mut summary = serde_json::Map::new();
     let mut config_paths = Vec::new();
+    let mut configured_slugs = Vec::new();
     for (cid, res) in &results {
         let label = cid.slug();
         match res {
@@ -416,6 +440,7 @@ fn step_configure_clients(cfg: &PipelineConfig, emitter: &Emitter) -> Result<()>
                     ApplyAction::ManualPending => "manual-pending",
                 };
                 summary.insert(label.to_string(), serde_json::Value::String(s.into()));
+                configured_slugs.push(label.to_string());
             }
             Err(e) => {
                 summary.insert(
@@ -443,7 +468,7 @@ fn step_configure_clients(cfg: &PipelineConfig, emitter: &Emitter) -> Result<()>
             "with_hooks": cfg.with_hooks,
         }),
     );
-    Ok(())
+    Ok(configured_slugs)
 }
 
 fn path_for_client(cid: ClientId) -> Option<String> {
@@ -585,18 +610,23 @@ async fn step_seed_subjects(cfg: &PipelineConfig, emitter: &Emitter) -> Result<(
     Ok(())
 }
 
-fn step_configure_adapters(cfg: &PipelineConfig, emitter: &Emitter) -> Result<()> {
+/// Configure-adapters step. Returns the slugs of adapters whose
+/// spawn is wired up today (only `fs` in v0.4 — gmail / github
+/// register in skills.toml as `manual-pending` and surface in the
+/// step's detail but don't flip `Outcome.adapters_enabled` until
+/// their OAuth/PAT plumbing lands).
+fn step_configure_adapters(cfg: &PipelineConfig, emitter: &Emitter) -> Result<Vec<String>> {
     if !cfg.includes(StepName::ConfigureAdapters) {
-        return Ok(());
+        return Ok(Vec::new());
     }
     emitter.step_started(StepName::ConfigureAdapters);
     if cfg.skip_adapters {
         emitter.step_skipped(StepName::ConfigureAdapters, "--skip-adapters");
-        return Ok(());
+        return Ok(Vec::new());
     }
     if cfg.dry_run {
         emitter.step_skipped(StepName::ConfigureAdapters, "dry-run");
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     // Read existing manifest so we don't clobber sibling adapter
@@ -651,10 +681,10 @@ fn step_configure_adapters(cfg: &PipelineConfig, emitter: &Emitter) -> Result<()
         serde_json::json!({
             "skills_toml": path.to_string_lossy(),
             "adapters": serde_json::Value::Object(summary),
-            "enabled_slugs": enabled_slugs,
+            "enabled_slugs": enabled_slugs.clone(),
         }),
     );
-    Ok(())
+    Ok(enabled_slugs)
 }
 
 async fn step_doctor(cfg: &PipelineConfig, emitter: &Emitter) -> Result<DoctorSummary> {

--- a/crates/ctxd-cli/tests/hook_silent_failure.rs
+++ b/crates/ctxd-cli/tests/hook_silent_failure.rs
@@ -1,0 +1,179 @@
+//! Hooks must never surface errors to Claude Code.
+//!
+//! `ctxd hook <slug>` is wired into `~/.claude/settings.json` by
+//! `ctxd onboard --with-hooks`. Once written, a hook entry can outlive
+//! its DB target — e.g. a sandboxed onboard run with
+//! `CTXD_DATA_DIR=$(mktemp -d)` writes a hook pointing at the tempdir,
+//! the tempdir is later wiped, and the hook keeps firing on every
+//! Claude Code session end. If the hook propagates SQLITE_CANTOPEN
+//! (code 14) as a non-zero exit, Claude Code prints "Stop hook error"
+//! into the user's chat on every Stop event — a permanent visible
+//! failure mode they can only break out of by re-running onboard.
+//!
+//! Contract: the hook subcommand is best-effort. Any failure (DB path
+//! resolves to a wiped tempdir, parent dir missing, exclusive lock,
+//! permission denied, malformed slug, malformed payload) MUST exit 0
+//! with a stderr warn. The happy path appends one event under
+//! `/me/sessions/<slug>` and exits 0.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+fn ctxd_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_ctxd")
+}
+
+fn run_hook_with_stdin(args: &[&str], stdin_payload: &[u8]) -> std::process::Output {
+    let mut child = Command::new(ctxd_bin())
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn ctxd");
+    if let Some(mut sin) = child.stdin.take() {
+        sin.write_all(stdin_payload).expect("write stdin");
+    }
+    child.wait_with_output().expect("wait")
+}
+
+#[test]
+fn hook_exits_zero_when_db_path_does_not_exist() {
+    // Reproduces the real-world failure: settings.json points at a
+    // tempdir that was wiped after a sandboxed onboard run.
+    let nonexistent = "/var/folders/__ctxd_does_not_exist__/ctxd.db";
+    let out = run_hook_with_stdin(
+        &[
+            "--db",
+            nonexistent,
+            "hook",
+            "--cap-file",
+            "/tmp/whatever-missing.bk",
+            "stop",
+        ],
+        br#"{"session_id":"test","hook_event_name":"Stop"}"#,
+    );
+    assert!(
+        out.status.success(),
+        "exit={:?} stdout={} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ctxd hook:") && stderr.contains("best-effort"),
+        "expected best-effort warn on stderr, got: {stderr}"
+    );
+}
+
+#[test]
+fn hook_exits_zero_when_db_parent_dir_does_not_exist() {
+    // Even more aggressive: parent dir doesn't exist, so SQLite can't
+    // create the journal. Still must not propagate.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let phantom = dir.path().join("nope/never/created/ctxd.db");
+    let out = run_hook_with_stdin(
+        &[
+            "--db",
+            phantom.to_str().unwrap(),
+            "hook",
+            "--cap-file",
+            "/tmp/whatever.bk",
+            "stop",
+        ],
+        b"{}",
+    );
+    assert!(
+        out.status.success(),
+        "exit={:?} stderr={}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+}
+
+#[test]
+fn hook_appends_event_on_happy_path() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("ctxd.db");
+    let out = run_hook_with_stdin(
+        &[
+            "--db",
+            db.to_str().unwrap(),
+            "hook",
+            "--cap-file",
+            "/tmp/whatever.bk",
+            "user-prompt-submit",
+        ],
+        br#"{"session_id":"abc","prompt":"hi"}"#,
+    );
+    assert!(out.status.success(), "hook should succeed: {out:?}");
+
+    // Read it back via the same binary so we exercise the full
+    // round-trip rather than a library shortcut.
+    let read = Command::new(ctxd_bin())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "read",
+            "--subject",
+            "/me/sessions/user-prompt-submit",
+        ])
+        .output()
+        .expect("read");
+    assert!(read.status.success(), "read failed: {read:?}");
+    let body = String::from_utf8_lossy(&read.stdout);
+    assert!(
+        body.contains("hook.user-prompt-submit"),
+        "expected event type in output: {body}"
+    );
+    assert!(
+        body.contains("\"prompt\": \"hi\""),
+        "expected payload in output: {body}"
+    );
+}
+
+#[test]
+fn hook_handles_invalid_slug_silently() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("ctxd.db");
+    let out = run_hook_with_stdin(
+        &[
+            "--db",
+            db.to_str().unwrap(),
+            "hook",
+            "--cap-file",
+            "/tmp/whatever.bk",
+            // Slug with characters that break Subject parsing — e.g.
+            // a leading slash would generate a malformed
+            // /me/sessions//foo path.
+            "/bad-slug",
+        ],
+        b"{}",
+    );
+    assert!(
+        out.status.success(),
+        "invalid slug must not propagate: {out:?}"
+    );
+}
+
+#[test]
+fn hook_handles_non_json_payload_silently() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let db = dir.path().join("ctxd.db");
+    let out = run_hook_with_stdin(
+        &[
+            "--db",
+            db.to_str().unwrap(),
+            "hook",
+            "--cap-file",
+            "/tmp/whatever.bk",
+            "stop",
+        ],
+        b"this is not json at all",
+    );
+    assert!(
+        out.status.success(),
+        "non-json payload must not propagate: {out:?}"
+    );
+}


### PR DESCRIPTION
## Summary

v0.4.1 stability rollup. Three independent bug fixes that collectively kill the user-facing failure modes shipped in v0.4.0.

1. **`ctxd onboard` path footgun** — invoking from any directory outside Application Support left caps signed against the wrong root_key.
2. **`Stop hook error: ... unable to open database file`** spamming Claude Code chat on every session end.
3. **MCP stdio proxy** emitting empty frames for JSON-RPC notifications (Claude Desktop log noise).

---

## 1. `--db` defaults to `paths::default_db_path()` instead of `"ctxd.db"`

This is the root cause of the v0.4.0 onboard failure. With the v0.4.0 default:

| | Foreground `ctxd onboard` | Launchd-spawned daemon |
|---|---|---|
| **DB path** | `<cwd>/ctxd.db` (relative) | `~/Library/Application Support/ctxd/ctxd.db` (canonical) |
| **Root_key** | Generated against `<cwd>/ctxd.db` | Generated against canonical DB |
| **Pidfile** | `<cwd>/ctxd.db.pid` | `<canonical>/ctxd.db.pid` |

Caps minted by the foreground command were signed by the cwd-DB's root_key but the daemon verified them against a different root_key — every cap reported `biscuit error: error deserializing or verifying the token`. `service-start` polled the wrong pidfile and always hit the 10s deadline.

After this PR, both paths align by default. `CTXD_DATA_DIR` still overrides.

## 2. `service-start` probes both pidfile paths

Defense-in-depth. If a 0.4.0 binary runs against a 0.4.1-installed plist (or vice versa) the deadline still meets a working pidfile. `<cwd>/ctxd.db.pid` is tried first; `paths::default_db_path()` is the fallback.

## 3. `Outcome.clients_configured` + `Outcome.adapters_enabled` populate

The pipeline collected the data but never threaded it through. Closing line went from `done — 0 client(s) configured, 0 adapter(s) enabled` to `done — 3 client(s) configured` on a typical onboard.

## 4. `ctxd hook` is now best-effort end-to-end

Real user report: `Stop hook error: Failed with non-blocking status code: Error: failed to open event store / Caused by: ... (code: 14) unable to open database file`, repeating on every Stop event.

Root cause: hook entries in `~/.claude/settings.json` written during a sandboxed onboard run (`CTXD_DATA_DIR=$(mktemp -d) ctxd onboard`) point at the tempdir. When the tempdir is wiped, the hook keeps firing with the dead path. The Hook subcommand was supposed to be best-effort — and the docstring promised it — but `EventStore::open` propagated up the main error path before the Hook handler even ran, so any open-time failure surfaced as a non-zero exit.

Fix: short-circuit `Commands::Hook` before the upfront `EventStore::open` in `main()`, and run it through a dedicated `run_hook()` that wraps every fallible step (slug parse, store open, append) in best-effort handling — log to stderr, exit 0.

Five integration tests pin the contract (`tests/hook_silent_failure.rs`):

* nonexistent DB path → exit 0
* phantom parent dir → exit 0
* happy path → exit 0 + event in `/me/sessions/<slug>`
* invalid slug → exit 0
* non-JSON payload → exit 0

## 5. MCP stdio proxy doesn't emit empty frames

The proxy used to write a bare newline whenever the daemon answered `202 Accepted` to a JSON-RPC notification (no `id`, no response expected). Line-oriented MCP clients then tried to `JSON.parse("")` and surfaced "Unexpected end of JSON input" — visible in the Claude Desktop log around the `notifications/initialized` handshake. Now the proxy skips the write when the body is empty.

## Verification

```
$ ./target/debug/ctxd --version
ctxd 0.4.1

$ CTXD_DATA_DIR=$(mktemp -d) ./target/debug/ctxd onboard --skip-service --skip-adapters
  ✓ snapshot
  ✓ service-install (skipped via flag)
  ✓ configure-clients
  ✓ mint-capabilities
  ✓ seed-subjects
  ✓ doctor
  done — 3 client(s) configured, 0 adapter(s) enabled

$ echo '{"x":1}' | ./target/debug/ctxd --db /does/not/exist hook --cap-file /tmp/x stop
ctxd hook: open failed (best-effort): database error: ... (code: 14) unable to open database file
$ echo $?
0
```

`cargo build -p ctxd-cli` clean. `cargo test -p ctxd-cli` all 19 test binaries pass (5 new in `hook_silent_failure.rs`). `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean.

## Migration from v0.4.0

Documented in CHANGELOG.md. Two cleanups, depending on which symptom hit:

**If onboard timed out at service-start** (path bug):
```bash
launchctl bootout gui/$UID/com.ctxd.serve 2>/dev/null
launchctl bootout gui/$UID/dev.ctxd.daemon 2>/dev/null
rm -f ~/Library/LaunchAgents/{com.ctxd.serve,dev.ctxd.daemon}.plist
rm -rf "$HOME/Library/Application Support/ctxd/caps"
rm -f  "$HOME/Library/Application Support/ctxd/ctxd.db.pid"
ctxd onboard   # picks up the v0.4.1 default
```

**If Stop hook errors are spamming chat** (stale settings.json hook): upgrading to v0.4.1 silences the symptom immediately because hooks are now best-effort. To also clear the stale entry: `ctxd onboard --only configure-clients` rewrites settings.json with the canonical DB path.

After merge: tag `v0.4.1`, the release workflow takes over from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)